### PR TITLE
[#74] [KMM] [Backend] As a user, I can call api with access token

### DIFF
--- a/buildSrc/src/main/kotlin/appPackage/Dependency.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Dependency.kt
@@ -51,4 +51,7 @@ object Dependency {
     // Resources
     const val MOKO_RESOURCES_GENERATOR = "dev.icerock.moko:resources-generator:${Version.MOKO_RESOURCES}"
     const val MOKO_RESOURCES = "dev.icerock.moko:resources:${Version.MOKO_RESOURCES}"
+
+    // Turbine
+    const val TURBINE = "app.cash.turbine:turbine:${Version.TURBINE}"
 }

--- a/buildSrc/src/main/kotlin/appPackage/Dependency.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Dependency.kt
@@ -24,6 +24,7 @@ object Dependency {
     const val KTOR_ANDROID = "io.ktor:ktor-client-android:${Version.KTOR}"
     const val KTOR_IOS = "io.ktor:ktor-client-ios:${Version.KTOR}"
     const val KTOR_MOCK = "io.ktor:ktor-client-mock:${Version.KTOR}"
+    const val KTOR_AUTH = "io.ktor:ktor-client-auth:${Version.KTOR}"
 
     // BuildKonfig
     const val BUILD_KONFIG = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin:${Version.BUILD_KONFIG}"

--- a/buildSrc/src/main/kotlin/appPackage/Versions.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Versions.kt
@@ -21,4 +21,5 @@ object Version {
     const val MULTIPLATFORM_SETTINGS = "1.0.0-RC"
     const val SECURITY = "1.1.0-alpha03"
     const val MOKO_RESOURCES = "0.20.1"
+    const val TURBINE = "0.12.1"
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
                 implementation(Dependency.KTOR_JSON)
                 implementation(Dependency.KTOR_CONTENT_NEGOTIATION)
                 implementation(Dependency.KTOR_MOCK)
+                implementation(Dependency.KTOR_AUTH)
                 implementation(Dependency.COROUTINES_TEST)
                 implementation(Dependency.KOIN)
                 implementation(Dependency.KOIN_TEST)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -50,22 +50,23 @@ kotlin {
                 implementation(Dependency.KTOR_CONTENT_NEGOTIATION)
                 implementation(Dependency.KTOR_MOCK)
                 implementation(Dependency.KTOR_AUTH)
-                implementation(Dependency.COROUTINES_TEST)
                 implementation(Dependency.KOIN)
                 implementation(Dependency.KOIN_TEST)
                 implementation(project(Module.JSONAPI_CORE))
                 implementation(Dependency.KOTLIN_TEST)
-                implementation(Dependency.KOTEST_FRAMEWORK)
-                implementation(Dependency.KOTEST_ASSERTIONS)
                 implementation(Dependency.KOTEST_PROPERTY)
                 implementation(Dependency.MULTIPLATFORM_SETTINGS)
                 implementation(Dependency.MULTIPLATFORM_SETTINGS_SERIALIZATION)
-                implementation(Dependency.MULTIPLATFORM_SETTINGS_TEST)
             }
         }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(Dependency.COROUTINES_TEST)
+                implementation(Dependency.KOTEST_FRAMEWORK)
+                implementation(Dependency.KOTEST_ASSERTIONS)
+                implementation(Dependency.TURBINE)
+                implementation(Dependency.MULTIPLATFORM_SETTINGS_TEST)
             }
         }
         val androidMain by getting {

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/NetworkClient.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/NetworkClient.kt
@@ -3,8 +3,6 @@ package co.nimblehq.blisskmmic.data.network.core
 import co.nimblehq.jsonapi.json.JsonApi
 import io.ktor.client.*
 import io.ktor.client.engine.*
-import io.ktor.client.plugins.auth.*
-import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
@@ -25,10 +23,10 @@ open class NetworkClient {
     }
 
     constructor(engine: HttpClientEngine? = null) {
-        if (engine == null) {
-            client = HttpClient(clientConfig())
+        client = if (engine == null) {
+            HttpClient(clientConfig())
         } else {
-            client = HttpClient(engine, clientConfig())
+            HttpClient(engine, clientConfig())
         }
     }
 
@@ -51,19 +49,12 @@ open class NetworkClient {
         }
     }
 
-    private fun clientConfig(): HttpClientConfig<*>.() -> Unit {
+    open fun clientConfig(): HttpClientConfig<*>.() -> Unit {
         return {
             install(Logging)
             install(ContentNegotiation) {
                 json(json)
             }
-            install(Auth) {
-                bearer(bearer())
-            }
         }
-    }
-
-    open fun bearer(): BearerAuthConfig.() -> Unit {
-        return {}
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
@@ -1,0 +1,33 @@
+package co.nimblehq.blisskmmic.data.network.core
+
+import co.nimblehq.blisskmmic.BuildKonfig
+import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSource
+import io.ktor.client.engine.*
+import io.ktor.client.plugins.auth.providers.*
+import io.ktor.http.*
+import kotlinx.coroutines.flow.singleOrNull
+
+class TokenizedNetworkClient: NetworkClient {
+
+    val localDataSource: LocalDataSource
+
+    constructor(
+        engine: HttpClientEngine? = null,
+        localDataSource: LocalDataSource
+    ) : super(engine) {
+        this.localDataSource = localDataSource
+    }
+
+    override fun bearer(): BearerAuthConfig.() -> Unit {
+        return {
+            loadTokens {
+                localDataSource.getToken().singleOrNull()?.run {
+                    BearerTokens(this.accessToken, this.refreshToken)
+                }
+            }
+            sendWithoutRequest { request ->
+                request.url.host != Url(BuildKonfig.BASE_URL).host
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
@@ -4,7 +4,7 @@ import co.nimblehq.blisskmmic.BuildKonfig
 import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSource
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.auth.providers.*
-import io.ktor.http.*
+import io.ktor.client.request.*
 import kotlinx.coroutines.flow.singleOrNull
 
 class TokenizedNetworkClient: NetworkClient {
@@ -26,7 +26,9 @@ class TokenizedNetworkClient: NetworkClient {
                 }
             }
             sendWithoutRequest { request ->
-                request.url.host != Url(BuildKonfig.BASE_URL).host
+                val builder = HttpRequestBuilder()
+                builder.url("${BuildKonfig.BASE_URL}")
+                request.url.host != builder.url.host
             }
         }
     }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.singleOrNull
 
 class TokenizedNetworkClient: NetworkClient {
 
-    val localDataSource: LocalDataSource
+    private val localDataSource: LocalDataSource
 
     constructor(
         engine: HttpClientEngine? = null,
@@ -39,7 +39,7 @@ class TokenizedNetworkClient: NetworkClient {
         return {
             loadTokens {
                 localDataSource.getToken().singleOrNull()?.run {
-                    BearerTokens(this.accessToken, this.refreshToken)
+                    BearerTokens(accessToken, refreshToken)
                 }
             }
             sendWithoutRequest { request ->

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClient.kt
@@ -2,9 +2,14 @@ package co.nimblehq.blisskmmic.data.network.core
 
 import co.nimblehq.blisskmmic.BuildKonfig
 import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSource
+import io.ktor.client.*
 import io.ktor.client.engine.*
+import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
+import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.flow.singleOrNull
 
 class TokenizedNetworkClient: NetworkClient {
@@ -18,7 +23,19 @@ class TokenizedNetworkClient: NetworkClient {
         this.localDataSource = localDataSource
     }
 
-    override fun bearer(): BearerAuthConfig.() -> Unit {
+    override fun clientConfig(): HttpClientConfig<*>.() -> Unit {
+        return {
+            install(Logging)
+            install(ContentNegotiation) {
+                json(json)
+            }
+            install(Auth) {
+                bearer(bearerConfig())
+            }
+        }
+    }
+
+    private fun bearerConfig(): BearerAuthConfig.() -> Unit {
         return {
             loadTokens {
                 localDataSource.getToken().singleOrNull()?.run {

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/constants/Koin+Constants.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/constants/Koin+Constants.kt
@@ -1,0 +1,3 @@
+package co.nimblehq.blisskmmic.di.koin.constants
+
+const val TOKENIZED_NETWORK_CLIENT_KOIN = "TOKENIZED_NETWORK_CLIENT_KOIN"

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/NetworkModule.kt
@@ -1,11 +1,15 @@
 package co.nimblehq.blisskmmic.di.koin.modules
 
 import co.nimblehq.blisskmmic.data.network.core.NetworkClient
+import co.nimblehq.blisskmmic.data.network.core.TokenizedNetworkClient
 import co.nimblehq.blisskmmic.data.network.datasource.NetworkDataSource
 import co.nimblehq.blisskmmic.data.network.datasource.NetworkDataSourceImpl
+import co.nimblehq.blisskmmic.di.koin.constants.TOKENIZED_NETWORK_CLIENT_KOIN
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val networkModule = module {
     single { NetworkClient() }
     single<NetworkDataSource> { NetworkDataSourceImpl(get()) }
+    factory(named(TOKENIZED_NETWORK_CLIENT_KOIN)) { TokenizedNetworkClient(null, get()) }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/datasource/NetworkDataSourceTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/datasource/NetworkDataSourceTest.kt
@@ -56,7 +56,7 @@ class NetworkDataSourceTest {
 
     @Test
     fun `When calling reset password with success response, it returns correct object`() = runTest {
-        val engine = jsonMockEngine(RESET_PASSWORD_JSON_RESULT)
+        val engine = jsonMockEngine(RESET_PASSWORD_JSON_RESULT, "passwords")
         val networkClient = NetworkClient(engine = engine)
         val dataSource = NetworkDataSourceImpl(networkClient)
         dataSource

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/datasource/NetworkDataSourceTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/datasource/NetworkDataSourceTest.kt
@@ -9,6 +9,7 @@ import co.nimblehq.blisskmmic.helpers.json.LOG_IN_JSON_RESULT
 import co.nimblehq.blisskmmic.helpers.json.RESET_PASSWORD_JSON_RESULT
 import co.nimblehq.blisskmmic.helpers.mock.ktor.jsonMockEngine
 import co.nimblehq.jsonapi.model.JsonApiException
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
@@ -23,7 +24,7 @@ class NetworkDataSourceTest {
 
     @Test
     fun `When calling log in with success response, it returns correct object`() = runTest {
-        val engine = jsonMockEngine(LOG_IN_JSON_RESULT)
+        val engine = jsonMockEngine(LOG_IN_JSON_RESULT, "oauth/token")
         val networkClient = NetworkClient(engine = engine)
         val dataSource = NetworkDataSourceImpl(networkClient)
         dataSource
@@ -35,14 +36,14 @@ class NetworkDataSourceTest {
 
     @Test
     fun `When calling log in with failure response, it returns correct error`() = runTest {
-        val engine = jsonMockEngine(ERROR_JSON_RESULT)
+        val engine = jsonMockEngine(ERROR_JSON_RESULT, "oauth/token")
         val networkClient = NetworkClient(engine = engine)
         val dataSource = NetworkDataSourceImpl(networkClient)
         dataSource
             .logIn(LoginTargetType("", ""))
             .catch { error ->
                 when(error) {
-                    is JsonApiException -> error.errors.map { it.code }.contains("invalid_token") shouldBe true
+                    is JsonApiException -> error.errors.map { it.code } shouldContain "invalid_token"
                     else -> fail("Should not return incorrect error type")
                 }
             }

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/NetworkClientTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/NetworkClientTest.kt
@@ -1,5 +1,7 @@
 package co.nimblehq.blisskmmic.data.network.core
 
+import co.nimblehq.blisskmmic.BuildKonfig
+import co.nimblehq.blisskmmic.data.network.helpers.API_VERSION
 import co.nimblehq.blisskmmic.helpers.mock.NetworkMockModel
 import co.nimblehq.blisskmmic.helpers.mock.NETWORK_MOCK_MODEL_RESULT
 import co.nimblehq.blisskmmic.helpers.mock.ktor.jsonMockEngine
@@ -10,14 +12,20 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.fail
 
 @ExperimentalCoroutinesApi
 class NetworkClientTest {
 
-    val path = "/user"
-    val request = HttpRequestBuilder(path = path)
+    private val path = "user"
+    private val request = HttpRequestBuilder()
+
+    @BeforeTest
+    fun setUp() {
+        request.url("$BuildKonfig.BASE_URL$API_VERSION$path")
+    }
 
     @Test
     fun `when calling fetch, it returns correct object`() = runTest {

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/NetworkClientTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/NetworkClientTest.kt
@@ -1,26 +1,49 @@
 package co.nimblehq.blisskmmic.data.network.core
 
-import co.nimblehq.blisskmmic.helpers.mock.NETWORK_MOCK_MODEL_RESULT
 import co.nimblehq.blisskmmic.helpers.mock.NetworkMockModel
+import co.nimblehq.blisskmmic.helpers.mock.NETWORK_MOCK_MODEL_RESULT
 import co.nimblehq.blisskmmic.helpers.mock.ktor.jsonMockEngine
+import co.nimblehq.jsonapi.model.JsonApiException
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.fail
 
 @ExperimentalCoroutinesApi
 class NetworkClientTest {
 
-    val engine = jsonMockEngine(NETWORK_MOCK_MODEL_RESULT)
+    val path = "/user"
+    val request = HttpRequestBuilder(path = path)
 
     @Test
-    fun testMockModel() = runTest {
+    fun `when calling fetch, it returns correct object`() = runTest {
+        val engine = jsonMockEngine(NETWORK_MOCK_MODEL_RESULT, path)
         val networkClient = NetworkClient(engine = engine)
         networkClient
-            .fetch<NetworkMockModel>(HttpRequestBuilder())
+            .fetch<NetworkMockModel>(request)
             .collect {
                 it.title shouldBe "Hello"
+            }
+    }
+
+    @Test
+    fun `when calling fetch with invalid path, it returns correct object`() = runTest {
+        val engine = jsonMockEngine(NETWORK_MOCK_MODEL_RESULT, "")
+        val networkClient = NetworkClient(engine = engine)
+        networkClient
+            .fetch<NetworkMockModel>(request)
+            .catch { error ->
+                when(error) {
+                    is JsonApiException -> error.errors.map { it.code } shouldContain "not_found"
+                    else -> fail("Should not return incorrect error type")
+                }
+            }
+            .collect {
+                fail("Should not return object")
             }
     }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClientTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClientTest.kt
@@ -1,0 +1,81 @@
+package co.nimblehq.blisskmmic.data.network.core
+
+import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSource
+import co.nimblehq.blisskmmic.data.database.datasource.MockLocalDataSource
+import co.nimblehq.blisskmmic.data.database.model.TokenDatabaseModel
+import co.nimblehq.blisskmmic.helpers.mock.NETWORK_MOCK_MODEL_RESULT
+import co.nimblehq.blisskmmic.helpers.mock.NetworkMockModel
+import co.nimblehq.blisskmmic.helpers.mock.ktor.jsonTokenizedMockEngine
+import co.nimblehq.jsonapi.model.JsonApiException
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mocker
+import org.kodein.mock.UsesMocks
+import kotlin.test.Test
+import kotlin.test.fail
+
+@ExperimentalCoroutinesApi
+@UsesMocks(LocalDataSource::class)
+class TokenizedNetworkClientTest {
+
+    val token = TokenDatabaseModel(
+        "Access",
+        "",
+        1,
+        "",
+        1
+    )
+    val path = "/user"
+    val request = HttpRequestBuilder(path = path)
+
+    @Test
+    fun `when calling fetch, it returns correct object`() = runTest {
+        val mocker = Mocker()
+        val localDataSource = MockLocalDataSource(mocker)
+        mocker.every {
+            localDataSource.getToken()
+        } returns flow { emit(token) }
+        val engine = jsonTokenizedMockEngine(
+            NETWORK_MOCK_MODEL_RESULT,
+            token.accessToken,
+            path
+        )
+        val networkClient = TokenizedNetworkClient(engine = engine, localDataSource)
+        networkClient
+            .fetch<NetworkMockModel>(request)
+            .collect {
+                it.title shouldBe "Hello"
+            }
+    }
+
+    @Test
+    fun `when calling fetch with incorrect token, it returns correct error`() = runTest {
+        val mocker = Mocker()
+        val localDataSource = MockLocalDataSource(mocker)
+        mocker.every {
+            localDataSource.getToken()
+        } returns flow { emit(token) }
+        val engine = jsonTokenizedMockEngine(
+            NETWORK_MOCK_MODEL_RESULT,
+            "no access",
+            path
+        )
+        val networkClient = TokenizedNetworkClient(engine = engine, localDataSource)
+        networkClient
+            .fetch<NetworkMockModel>(request)
+            .catch { error ->
+                when(error) {
+                    is JsonApiException -> error.errors.map { it.code } shouldContain "unauthorized"
+                    else -> fail("Should not return incorrect error type")
+                }
+            }
+            .collect {
+                fail("Should not return object")
+            }
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClientTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClientTest.kt
@@ -1,8 +1,10 @@
 package co.nimblehq.blisskmmic.data.network.core
 
+import co.nimblehq.blisskmmic.BuildKonfig
 import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSource
 import co.nimblehq.blisskmmic.data.database.datasource.MockLocalDataSource
 import co.nimblehq.blisskmmic.data.database.model.TokenDatabaseModel
+import co.nimblehq.blisskmmic.data.network.helpers.API_VERSION
 import co.nimblehq.blisskmmic.helpers.mock.NETWORK_MOCK_MODEL_RESULT
 import co.nimblehq.blisskmmic.helpers.mock.NetworkMockModel
 import co.nimblehq.blisskmmic.helpers.mock.ktor.jsonTokenizedMockEngine
@@ -10,12 +12,14 @@ import co.nimblehq.jsonapi.model.JsonApiException
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
+import io.ktor.http.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.kodein.mock.Mocker
 import org.kodein.mock.UsesMocks
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.fail
 
@@ -23,20 +27,27 @@ import kotlin.test.fail
 @UsesMocks(LocalDataSource::class)
 class TokenizedNetworkClientTest {
 
-    val token = TokenDatabaseModel(
+    private val mocker = Mocker()
+    private val localDataSource = MockLocalDataSource(mocker)
+
+    private val token = TokenDatabaseModel(
         "Access",
         "",
         1,
         "",
         1
     )
-    val path = "/user"
-    val request = HttpRequestBuilder(path = path)
+    private val path = "user"
+    private val request = HttpRequestBuilder()
+
+    @BeforeTest
+    fun setUp() {
+        mocker.reset()
+        request.url("$BuildKonfig.BASE_URL$API_VERSION$path")
+    }
 
     @Test
     fun `when calling fetch, it returns correct object`() = runTest {
-        val mocker = Mocker()
-        val localDataSource = MockLocalDataSource(mocker)
         mocker.every {
             localDataSource.getToken()
         } returns flow { emit(token) }
@@ -55,8 +66,6 @@ class TokenizedNetworkClientTest {
 
     @Test
     fun `when calling fetch with incorrect token, it returns correct error`() = runTest {
-        val mocker = Mocker()
-        val localDataSource = MockLocalDataSource(mocker)
         mocker.every {
             localDataSource.getToken()
         } returns flow { emit(token) }

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/json/ErrorJsonResult.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/json/ErrorJsonResult.kt
@@ -3,3 +3,11 @@ package co.nimblehq.blisskmmic.helpers.json
 const val ERROR_JSON_RESULT = """
     {"errors":[{"detail":"The access token is invalid","code":"invalid_token"}]}
 """
+
+const val NOT_FOUND_JSON_RESULT = """
+    {"errors":[{"detail":"Not found","code":"not_found"}]}
+"""
+
+const val UNAUTHORIZED_JSON_RESULT = """
+    {"errors":[{"detail":"Not found","code":"unauthorized"}]}
+"""

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/json/ErrorJsonResult.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/json/ErrorJsonResult.kt
@@ -9,5 +9,5 @@ const val NOT_FOUND_JSON_RESULT = """
 """
 
 const val UNAUTHORIZED_JSON_RESULT = """
-    {"errors":[{"detail":"Not found","code":"unauthorized"}]}
+    {"errors":[{"detail":"Unauthorized","code":"unauthorized"}]}
 """

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/mock/ktor/ApiPath.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/mock/ktor/ApiPath.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.blisskmmic.helpers.mock.ktor
+
+import co.nimblehq.blisskmmic.data.network.helpers.API_VERSION
+
+fun apiPath(fullPath: String): String {
+    return fullPath.split(API_VERSION).last()
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/mock/ktor/JsonTokenizedMockEngine.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/mock/ktor/JsonTokenizedMockEngine.kt
@@ -1,23 +1,36 @@
 package co.nimblehq.blisskmmic.helpers.mock.ktor
 
 import co.nimblehq.blisskmmic.helpers.json.NOT_FOUND_JSON_RESULT
+import co.nimblehq.blisskmmic.helpers.json.UNAUTHORIZED_JSON_RESULT
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 
-fun jsonMockEngine(
+fun jsonTokenizedMockEngine(
     jsonString: String,
+    accessToken: String?,
     path: String,
     statusCode: HttpStatusCode = HttpStatusCode.OK
 ): MockEngine {
-     fun MockRequestHandleScope.response(request: HttpRequestData): HttpResponseData {
+    fun MockRequestHandleScope.response(
+        request: HttpRequestData
+    ): HttpResponseData {
         val responseHeader = headersOf(HttpHeaders.ContentType, "application/json")
+        val auth = request.headers["Authorization"].toString()
         return if (apiPath(request.url.fullPath) == path) {
-            respond(
-                jsonString,
-                statusCode,
-                responseHeader
-            )
+            return if (auth == "Bearer $accessToken") {
+                respond(
+                    jsonString,
+                    statusCode,
+                    responseHeader
+                )
+            } else {
+                respondError(
+                    HttpStatusCode.Unauthorized,
+                    UNAUTHORIZED_JSON_RESULT,
+                    responseHeader
+                )
+            }
         } else {
             respondError(
                 HttpStatusCode.NotFound,


### PR DESCRIPTION
- close #74 

## What happened

Add a new network client with bearer token.
 
## Insight

- Inherit `NetworkClient` to `TokenizedNetworkClient`.
- Refactor `NetworkClient` to allow editing of engine plugin.
- Add `path` to test of `NetworkClient` to throw error when client passing a wrong path.
 
## Proof Of Work


<img width="1552" alt="Screen Shot 2022-11-21 at 12 25 53" src="https://user-images.githubusercontent.com/6356137/202990032-feb47031-c96a-4bb0-88c0-57b405ef84ee.png">

<img width="401" alt="Screen Shot 2022-11-18 at 10 59 00" src="https://user-images.githubusercontent.com/6356137/202613772-797711ca-d4a1-489a-8370-d6d9995c72b6.png">
