### PR TITLE
[#82] [iOS] [UI] Fix: Login screen image not matching device

### DIFF
--- a/iosApp/Survey.xcodeproj/project.pbxproj
+++ b/iosApp/Survey.xcodeproj/project.pbxproj
@@ -1583,7 +1583,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.bliss.kmm-ic";
 				PRODUCT_NAME = Survey;
 				SDKROOT = iphoneos;
@@ -1843,7 +1843,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.bliss.kmm-ic";
 				PRODUCT_NAME = Survey;
 				SDKROOT = iphoneos;
@@ -1869,7 +1869,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.bliss.kmm-ic";
 				PRODUCT_NAME = Survey;
 				SDKROOT = iphoneos;
@@ -1920,7 +1920,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.nimblehq.bliss.kmm-ic";
 				PRODUCT_NAME = Survey;
 				SDKROOT = iphoneos;

--- a/iosApp/Survey/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/Login/LoginView.swift
@@ -32,14 +32,14 @@ struct LoginView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .ignoresSafeArea()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
 
                 Assets.backgroundBlur
                     .image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .ignoresSafeArea()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
                     .opacity(animating ? 1.0 : 0.0)
 
                 VStack(

--- a/iosApp/Survey/Sources/Presentation/Modules/ResetPassword/ResetPasswordView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/ResetPassword/ResetPasswordView.swift
@@ -21,7 +21,7 @@ struct ResetPasswordView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .ignoresSafeArea()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
 
                 VStack(
                     alignment: .center,


### PR DESCRIPTION
- close #82 

## What happened

Fix background image size not matching.

## Insight

Use GeometricRenderer size instead of infinite because GeometricRenderer does not know the device size. 
 
## Proof Of Work

Animation is smooth.

https://user-images.githubusercontent.com/6356137/203228220-ca37be09-0e0a-4128-83bb-7146fb1685ad.mov

