### PR TITLE
[Bug] Fix animations causing tests failures 

### DIFF
--- a/iosApp/Survey.xcodeproj/project.pbxproj
+++ b/iosApp/Survey.xcodeproj/project.pbxproj
@@ -44,6 +44,11 @@
 		09636B3328D8272E00A5CB97 /* ViewId+General.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09636B2F28D8267D00A5CB97 /* ViewId+General.swift */; };
 		09636B3628D8285700A5CB97 /* KeyboardScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09636B3428D8284600A5CB97 /* KeyboardScreen.swift */; };
 		0964B18D293F28DC00946FA1 /* TimeInterval+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C2F4012934588400F44818 /* TimeInterval+Constants.swift */; };
+		0964B1C62940514000946FA1 /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1C52940514000946FA1 /* LaunchArgument.swift */; };
+		0964B1C72940514C00946FA1 /* LaunchArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1C52940514000946FA1 /* LaunchArgument.swift */; };
+		0964B1CA294051CE00946FA1 /* ArgumentedXCUIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1C8294051C300946FA1 /* ArgumentedXCUIApplication.swift */; };
+		0964B1CC2940530200946FA1 /* UITestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1CB2940530200946FA1 /* UITestHelper.swift */; };
+		0964B1CE294054B300946FA1 /* Double+AnimationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1CD294054B300946FA1 /* Double+AnimationDuration.swift */; };
 		0982A79E2921DF7E00FC1976 /* SurveySelectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7982921DE6700FC1976 /* SurveySelectionSpec.swift */; };
 		0982A7A62921DFE800FC1976 /* ResetPasswordSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7A32921DFE700FC1976 /* ResetPasswordSpec.swift */; };
 		0982A7DF29222EA800FC1976 /* LoginSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7DE29222EA800FC1976 /* LoginSpec.swift */; };
@@ -178,6 +183,10 @@
 		09636B2A28D8255D00A5CB97 /* ScreenProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenProtocol.swift; sourceTree = "<group>"; };
 		09636B2F28D8267D00A5CB97 /* ViewId+General.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewId+General.swift"; sourceTree = "<group>"; };
 		09636B3428D8284600A5CB97 /* KeyboardScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardScreen.swift; sourceTree = "<group>"; };
+		0964B1C52940514000946FA1 /* LaunchArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
+		0964B1C8294051C300946FA1 /* ArgumentedXCUIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentedXCUIApplication.swift; sourceTree = "<group>"; };
+		0964B1CB2940530200946FA1 /* UITestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHelper.swift; sourceTree = "<group>"; };
+		0964B1CD294054B300946FA1 /* Double+AnimationDuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+AnimationDuration.swift"; sourceTree = "<group>"; };
 		0982A7982921DE6700FC1976 /* SurveySelectionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveySelectionSpec.swift; sourceTree = "<group>"; };
 		0982A7A32921DFE700FC1976 /* ResetPasswordSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResetPasswordSpec.swift; sourceTree = "<group>"; };
 		0982A7DE29222EA800FC1976 /* LoginSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginSpec.swift; sourceTree = "<group>"; };
@@ -482,6 +491,15 @@
 			path = General;
 			sourceTree = "<group>";
 		};
+		0964B1C4294050E100946FA1 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				0964B1C52940514000946FA1 /* LaunchArgument.swift */,
+				0964B1CB2940530200946FA1 /* UITestHelper.swift */,
+			);
+			path = UITests;
+			sourceTree = "<group>";
+		};
 		0982A7972921DE6700FC1976 /* SurveySelection */ = {
 			isa = PBXGroup;
 			children = (
@@ -607,6 +625,7 @@
 			isa = PBXGroup;
 			children = (
 				09C2F40829346A8500F44818 /* XCUIElement+Label.swift */,
+				0964B1C8294051C300946FA1 /* ArgumentedXCUIApplication.swift */,
 			);
 			path = XCTest;
 			sourceTree = "<group>";
@@ -845,6 +864,7 @@
 			children = (
 				71A1F95D20E1E58589F4CD31 /* Constants.swift */,
 				09495FC8291106A00036BDFB /* Constants+SystemImage.swift */,
+				0964B1CD294054B300946FA1 /* Double+AnimationDuration.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -1038,6 +1058,7 @@
 		E8FA76B3139104BA8189B8C0 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				0964B1C4294050E100946FA1 /* UITests */,
 				09CE772C28E2ED2300EAA9EE /* KMM */,
 				09636B0928D48CE800A5CB97 /* Typealiases */,
 				09636AF428D47A1400A5CB97 /* Rswift */,
@@ -1472,6 +1493,7 @@
 				09CE773328E2ED2300EAA9EE /* KoinApplication.swift in Sources */,
 				0982A7E329222EFF00FC1976 /* RouteCoordinator.swift in Sources */,
 				09495F7828FFF2D50036BDFB /* ViewId+SurveySelection.swift in Sources */,
+				0964B1CC2940530200946FA1 /* UITestHelper.swift in Sources */,
 				09495F2A28EC43760036BDFB /* ViewId+SurveyLoading.swift in Sources */,
 				09495F2828EC38AD0036BDFB /* SkeletonTextView.swift in Sources */,
 				0982A880292F847900FC1976 /* ResetPassword+DataSource.swift in Sources */,
@@ -1484,11 +1506,13 @@
 				09CE771528E1AB0B00EAA9EE /* ViewId+ResetPassword.swift in Sources */,
 				09636B0B28D48CFD00A5CB97 /* Typealiases.swift in Sources */,
 				0982A7F6292371F000FC1976 /* StringResource+Localized.swift in Sources */,
+				0964B1CE294054B300946FA1 /* Double+AnimationDuration.swift in Sources */,
 				09636B0028D4860F00A5CB97 /* PrimaryTextField.swift in Sources */,
 				09495F6628FF97080036BDFB /* SplashView.swift in Sources */,
 				09495F82290109760036BDFB /* NotificationManager.swift in Sources */,
 				870924447B8C177450E77414 /* Optional+Unwrap.swift in Sources */,
 				0982A7E72922357C00FC1976 /* Font+Extensions.swift in Sources */,
+				0964B1C62940514000946FA1 /* LaunchArgument.swift in Sources */,
 				09CE772328E2B87700EAA9EE /* LoadingDialog.swift in Sources */,
 				09636AF628D47A1500A5CB97 /* R.generated.swift in Sources */,
 			);
@@ -1508,6 +1532,7 @@
 				0982A79E2921DF7E00FC1976 /* SurveySelectionSpec.swift in Sources */,
 				0982A7EB29223C3A00FC1976 /* SurveyLoadingSpec.swift in Sources */,
 				09C2F4032934588B00F44818 /* TimeInterval+Constants.swift in Sources */,
+				0964B1CA294051CE00946FA1 /* ArgumentedXCUIApplication.swift in Sources */,
 				09C2F40A29346A8800F44818 /* XCUIElement+Label.swift in Sources */,
 				09636B2128D821EA00A5CB97 /* ViewId.swift in Sources */,
 				0982A7DF29222EA800FC1976 /* LoginSpec.swift in Sources */,
@@ -1519,6 +1544,7 @@
 				09495F2B28EC43860036BDFB /* ViewId+SurveyLoading.swift in Sources */,
 				09636B2228D821ED00A5CB97 /* ViewId+Login.swift in Sources */,
 				09636B3128D8271D00A5CB97 /* LoginScreen.swift in Sources */,
+				0964B1C72940514C00946FA1 /* LaunchArgument.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/Survey/Resources/LaunchScreen/LaunchScreen.storyboard
+++ b/iosApp/Survey/Resources/LaunchScreen/LaunchScreen.storyboard
@@ -5,7 +5,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,19 +15,8 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Background" translatesAutoresizingMaskIntoConstraints="NO" id="O5r-dD-ZkG">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                            </imageView>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstAttribute="trailing" secondItem="O5r-dD-ZkG" secondAttribute="trailing" id="78f-ju-CwC"/>
-                            <constraint firstItem="O5r-dD-ZkG" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="PZO-Rx-Dw7"/>
-                            <constraint firstAttribute="bottom" secondItem="O5r-dD-ZkG" secondAttribute="bottom" id="R0p-Mv-Vv6"/>
-                            <constraint firstItem="O5r-dD-ZkG" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="uvd-8K-VlM"/>
-                        </constraints>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -36,10 +24,4 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="Background" width="375" height="812"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/iosApp/Survey/Sources/Application/AppDelegate.swift
+++ b/iosApp/Survey/Sources/Application/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        UITestHelper.shared.speedUpUITestAnimation()
         return true
     }
 }

--- a/iosApp/Survey/Sources/Constants/Double+AnimationDuration.swift
+++ b/iosApp/Survey/Sources/Constants/Double+AnimationDuration.swift
@@ -1,0 +1,19 @@
+//
+//  Double+AnimationDuration.swift
+//  Survey
+//
+//  Created by Bliss on 7/12/22.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+extension Double {
+
+    /// 0.7
+    static var appearing: Self { 0.7.speedModified }
+    /// 0.2
+    static var fast: Self { 0.2.speedModified }
+    /// 0.3
+    static var `default`: Self { 0.3.speedModified }
+}

--- a/iosApp/Survey/Sources/Presentation/Modules/Login/LoginView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/Login/LoginView.swift
@@ -20,7 +20,7 @@ struct LoginView: View {
     @State private var password: String = ""
     @State private var animating = false
 
-    private let animationDuration: Double = 0.7
+    private let animationDuration: Double = .appearing
 
     let coordinator: LoginCoordinator
 
@@ -70,8 +70,10 @@ struct LoginView: View {
         .accessibilityElement(children: .contain)
         .hideBackButtonTitle()
         .onAppear {
-            withAnimation(.easeIn(duration: animationDuration)) {
-                animating = true
+            DispatchQueue.main.async {
+                withAnimation(.easeIn(duration: animationDuration)) {
+                    animating = true
+                }
             }
         }
     }

--- a/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
@@ -29,7 +29,7 @@ struct SplashView: View {
         }
         .accessibility(.splash(.view))
         .onAppear {
-            withAnimation(.linear(duration: 0.2)) {
+            withAnimation(.linear(duration: .fast)) {
                 coordinator.showLogin()
             }
         }

--- a/iosApp/Survey/Sources/Presentation/Views/FadePaginationView.swift
+++ b/iosApp/Survey/Sources/Presentation/Views/FadePaginationView.swift
@@ -44,7 +44,7 @@ struct FadePaginationView<T>: View {
                             currentVisibility = 1.0 * max(0.0, turningVisibilityPercentage)
                         }
                         .onEnded { value in
-                            withAnimation(.easeInOut(duration: 0.3)) {
+                            withAnimation(.easeInOut(duration: .default)) {
                                 let velocity = self.velocity
                                 if velocity.dx < -turningSpeed {
                                     // Swipe back fast

--- a/iosApp/Survey/Sources/Supports/Helpers/UITests/LaunchArgument.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/UITests/LaunchArgument.swift
@@ -1,0 +1,28 @@
+//
+//  LaunchArgument.swift
+//  Survey
+//
+//  Created by Bliss on 7/12/22.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+enum LaunchArgumentKey: String {
+
+    case fastAnimation
+}
+
+enum LaunchEnvironment {
+
+    static func stringFor(_ key: LaunchArgumentKey) -> String? {
+        return ProcessInfo.processInfo.environment[key.rawValue]
+    }
+}
+
+enum LaunchArgument {
+
+    static func contains(_ key: LaunchArgumentKey) -> Bool {
+        return ProcessInfo.processInfo.arguments.contains(key.rawValue)
+    }
+}

--- a/iosApp/Survey/Sources/Supports/Helpers/UITests/UITestHelper.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/UITests/UITestHelper.swift
@@ -1,0 +1,49 @@
+//
+//  UITestHelper.swift
+//  Survey
+//
+//  Created by Bliss on 7/12/22.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import UIKit
+
+final class UITestHelper {
+
+    static let shared = UITestHelper()
+
+    var speed: Float = 1.0
+
+    var isRunningUITests: Bool {
+        LaunchArgument.contains(.fastAnimation)
+    }
+
+    func speedUpUITestAnimation() {
+        #if DEBUG
+            if isRunningUITests {
+                // swiftformat:disable:next numberFormatting
+                speed = 1_000.0
+                UIApplication
+                    .shared
+                    .connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .flatMap { $0.windows }
+                    .first { $0.isKeyWindow }?
+                    .layer
+                    .speed = speed
+                UIView.setAnimationsEnabled(false)
+            }
+        #endif
+    }
+}
+
+extension Double {
+
+    var speedModified: Double {
+        #if DEBUG
+            self / Double(UITestHelper.shared.speed)
+        #else
+            self
+        #endif
+    }
+}

--- a/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/Login/LoginSpec.swift
+++ b/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/Login/LoginSpec.swift
@@ -21,7 +21,7 @@ final class LoginSpec: QuickSpec {
             describe("its open") {
 
                 beforeEach {
-                    app = XCUIApplication()
+                    app = ArgumentedXCUIApplication()
                     loginScreen = LoginScreen(in: app)
                     app.launch()
                 }

--- a/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/ResetPassword/ResetPasswordSpec.swift
+++ b/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/ResetPassword/ResetPasswordSpec.swift
@@ -22,7 +22,7 @@ final class ResetPasswordSpec: QuickSpec {
             describe("its open") {
 
                 beforeEach {
-                    app = XCUIApplication()
+                    app = ArgumentedXCUIApplication()
                     loginScreen = LoginScreen(in: app)
                     app.launch()
                     loginScreen.waitForExistence(timeout: .default, \.images, with: .view)

--- a/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/SurveySelection/SurveyLoading/SurveyLoadingSpec.swift
+++ b/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/SurveySelection/SurveyLoading/SurveyLoadingSpec.swift
@@ -21,7 +21,7 @@ final class SurveyLoadingSpec: QuickSpec {
             describe("its open") {
 
                 beforeEach {
-                    app = XCUIApplication()
+                    app = ArgumentedXCUIApplication()
                     app.launch()
                     let loginFlow = LoginFlow(in: app)
                     loginFlow.execute()

--- a/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/SurveySelection/SurveySelectionSpec.swift
+++ b/iosApp/SurveyUITests/Sources/Specs/Presentation/Modules/SurveySelection/SurveySelectionSpec.swift
@@ -21,7 +21,7 @@ final class SurveySelectionSpec: QuickSpec {
             describe("its open") {
 
                 beforeEach {
-                    app = XCUIApplication()
+                    app = ArgumentedXCUIApplication()
                     app.launch()
                     let loginFlow = LoginFlow(in: app)
                     loginFlow.execute()

--- a/iosApp/SurveyUITests/Sources/Utilities/Extensions/XCTest/ArgumentedXCUIApplication.swift
+++ b/iosApp/SurveyUITests/Sources/Utilities/Extensions/XCTest/ArgumentedXCUIApplication.swift
@@ -1,0 +1,42 @@
+//
+//  FastXCUIApplication.swift
+//  Survey
+//
+//  Created by Bliss on 7/12/22.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import XCTest
+
+final class ArgumentedXCUIApplication: XCUIApplication {
+
+    override init() {
+        super.init()
+        isFastAnimation = true
+    }
+}
+
+extension ArgumentedXCUIApplication {
+
+    var isFastAnimation: Bool {
+        get {
+            LaunchArgument.contains(.fastAnimation)
+        }
+
+        set {
+            if newValue {
+                add(launchArguments: .fastAnimation)
+            } else {
+                remove(launchArguments: .fastAnimation)
+            }
+        }
+    }
+
+    func add(launchArguments argument: LaunchArgumentKey) {
+        launchArguments.append(argument.rawValue)
+    }
+
+    func remove(launchArguments argument: LaunchArgumentKey) {
+        launchArguments.removeAll(where: { $0 == argument.rawValue })
+    }
+}


### PR DESCRIPTION
## What happened

UITests is now more consistent.
  
## Insight

- Add launch arguments on the UITests.
- Launch arguments `fastAnimation` speed up animations in the app.
- Add constants for animation duration so speed up is easier.
- Use `DispatchQueue.main` with `onAppear` to fix animation not working properly when view is not fully loaded.
 
## Proof Of Work

Passed tests.