### PR TITLE
[#62] [iOS] [Integration] As a user, I can load my existing account account when one is persisted in local store

### DIFF
--- a/iosApp/Survey.xcodeproj/project.pbxproj
+++ b/iosApp/Survey.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		0964B1CC2940530200946FA1 /* UITestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1CB2940530200946FA1 /* UITestHelper.swift */; };
 		0964B1CE294054B300946FA1 /* Double+AnimationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1CD294054B300946FA1 /* Double+AnimationDuration.swift */; };
 		0964B1D02942F3A300946FA1 /* LoginView+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1CF2942F3A200946FA1 /* LoginView+DataSource.swift */; };
+		0964B1D92946FA8100946FA1 /* SplashView+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1D82946FA8100946FA1 /* SplashView+DataSource.swift */; };
+		0964B1DD2947021400946FA1 /* SplashViewDataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1DB2947008E00946FA1 /* SplashViewDataSourceSpec.swift */; };
 		0982A79E2921DF7E00FC1976 /* SurveySelectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7982921DE6700FC1976 /* SurveySelectionSpec.swift */; };
 		0982A7A62921DFE800FC1976 /* ResetPasswordSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7A32921DFE700FC1976 /* ResetPasswordSpec.swift */; };
 		0982A7DF29222EA800FC1976 /* LoginSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7DE29222EA800FC1976 /* LoginSpec.swift */; };
@@ -192,6 +194,8 @@
 		0964B1CB2940530200946FA1 /* UITestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHelper.swift; sourceTree = "<group>"; };
 		0964B1CD294054B300946FA1 /* Double+AnimationDuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+AnimationDuration.swift"; sourceTree = "<group>"; };
 		0964B1CF2942F3A200946FA1 /* LoginView+DataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LoginView+DataSource.swift"; sourceTree = "<group>"; };
+		0964B1D82946FA8100946FA1 /* SplashView+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SplashView+DataSource.swift"; sourceTree = "<group>"; };
+		0964B1DB2947008E00946FA1 /* SplashViewDataSourceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewDataSourceSpec.swift; sourceTree = "<group>"; };
 		0982A7982921DE6700FC1976 /* SurveySelectionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveySelectionSpec.swift; sourceTree = "<group>"; };
 		0982A7A32921DFE700FC1976 /* ResetPasswordSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResetPasswordSpec.swift; sourceTree = "<group>"; };
 		0982A7DE29222EA800FC1976 /* LoginSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginSpec.swift; sourceTree = "<group>"; };
@@ -318,6 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				09495F6528FF97070036BDFB /* SplashView.swift */,
+				0964B1D82946FA8100946FA1 /* SplashView+DataSource.swift */,
 			);
 			path = Splash;
 			sourceTree = "<group>";
@@ -366,6 +371,7 @@
 		09495FBB290B9CB60036BDFB /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				0964B1DA2947007D00946FA1 /* SplashView */,
 				09495FBC290B9CBD0036BDFB /* Login */,
 				09C2F3FA293093F600F44818 /* ResetPassword */,
 			);
@@ -506,6 +512,14 @@
 				0964B1CB2940530200946FA1 /* UITestHelper.swift */,
 			);
 			path = UITests;
+			sourceTree = "<group>";
+		};
+		0964B1DA2947007D00946FA1 /* SplashView */ = {
+			isa = PBXGroup;
+			children = (
+				0964B1DB2947008E00946FA1 /* SplashViewDataSourceSpec.swift */,
+			);
+			path = SplashView;
 			sourceTree = "<group>";
 		};
 		0982A7972921DE6700FC1976 /* SurveySelection */ = {
@@ -1506,6 +1520,7 @@
 				09495F2A28EC43760036BDFB /* ViewId+SurveyLoading.swift in Sources */,
 				09495F2828EC38AD0036BDFB /* SkeletonTextView.swift in Sources */,
 				0982A880292F847900FC1976 /* ResetPassword+DataSource.swift in Sources */,
+				0964B1D92946FA8100946FA1 /* SplashView+DataSource.swift in Sources */,
 				0982A80429278E9000FC1976 /* SurveyItemView.swift in Sources */,
 				09636B1528D8148C00A5CB97 /* ViewId.swift in Sources */,
 				0982A80529278E9000FC1976 /* SurveyLoading.swift in Sources */,
@@ -1564,6 +1579,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09C2F413293777ED00F44818 /* Combine+Collect.swift in Sources */,
+				0964B1DD2947021400946FA1 /* SplashViewDataSourceSpec.swift in Sources */,
 				5BBBFAF49689F25A8C1D57AB /* AutoMockable.generated.swift in Sources */,
 				09495F88290114230036BDFB /* NotificationManagerSpec.swift in Sources */,
 				0964B18D293F28DC00946FA1 /* TimeInterval+Constants.swift in Sources */,

--- a/iosApp/Survey/Sources/Application/AppDelegate.swift
+++ b/iosApp/Survey/Sources/Application/AppDelegate.swift
@@ -17,6 +17,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
         UITestHelper.shared.speedUpUITestAnimation()
+        UITestHelper.shared.clearKeychainUITest()
         return true
     }
 }

--- a/iosApp/Survey/Sources/Presentation/Coordinator/AppCoordinator.swift
+++ b/iosApp/Survey/Sources/Presentation/Coordinator/AppCoordinator.swift
@@ -21,7 +21,7 @@ struct AppCoordinator: View {
             case .resetPassword:
                 ResetPasswordView()
             case .splash:
-                SplashView(coordinator: coordinator)
+                SplashView(dataSource: .init(coordinator: coordinator))
             case .surveySelection:
                 SurveySelectionView()
             case .surveyLoading:

--- a/iosApp/Survey/Sources/Presentation/Coordinator/AppCoordinator.swift
+++ b/iosApp/Survey/Sources/Presentation/Coordinator/AppCoordinator.swift
@@ -21,7 +21,7 @@ struct AppCoordinator: View {
             case .resetPassword:
                 ResetPasswordView()
             case .splash:
-                SplashView(dataSource: .init(coordinator: coordinator))
+                SplashView(coordinator: coordinator)
             case .surveySelection:
                 SurveySelectionView()
             case .surveyLoading:

--- a/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView+DataSource.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView+DataSource.swift
@@ -37,11 +37,11 @@ extension SplashView {
             self.coordinator = coordinator
             createPublisher(for: viewModel.viewStateNative)
                 .dropFirst()
-                .receive(on: DispatchQueue.main)
                 .catch { _ -> Just<SplashViewState> in
                     let splashViewState = SplashViewState()
                     return Just(splashViewState)
                 }
+                .receive(on: DispatchQueue.main)
                 .sink { [weak self] value in
                     guard let self = self else { return }
                     self.updateStates(value)

--- a/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView+DataSource.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView+DataSource.swift
@@ -1,0 +1,68 @@
+//
+//  SplashView+DataSource.swift
+//  Survey
+//
+//  Created by Bliss on 12/12/22.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+import KMPNativeCoroutinesCombine
+import Shared
+import SwiftUI
+
+// sourcery: AutoMockable
+protocol SplashCoordinator {
+
+    func showLogin()
+    func showHomeLoading()
+}
+
+extension SplashView {
+
+    final class DataSource: ObservableObject {
+
+        let viewModel: SplashViewModel
+        let coordinator: SplashCoordinator
+
+        @Published private(set) var viewState = SplashViewState()
+
+        private var cancellables = Set<AnyCancellable>()
+
+        init(
+            viewModel: SplashViewModel = KoinApplication.shared.inject(),
+            coordinator: SplashCoordinator
+        ) {
+            self.viewModel = viewModel
+            self.coordinator = coordinator
+            createPublisher(for: viewModel.viewStateNative)
+                .dropFirst()
+                .receive(on: DispatchQueue.main)
+                .catch { _ -> Just<SplashViewState> in
+                    let splashViewState = SplashViewState()
+                    return Just(splashViewState)
+                }
+                .sink { [weak self] value in
+                    guard let self = self else { return }
+                    self.updateStates(value)
+                }
+                .store(in: &cancellables)
+        }
+
+        func checkLogin() {
+            viewModel.checkLogin()
+        }
+
+        private func updateStates(_ state: SplashViewState) {
+            viewState = state
+            guard !viewState.isLoading else { return }
+            withAnimation(.linear(duration: .fast)) {
+                if viewState.isLogin {
+                    coordinator.showHomeLoading()
+                } else {
+                    coordinator.showLogin()
+                }
+            }
+        }
+    }
+}

--- a/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct SplashView: View {
 
-    @StateObject var dataSource: DataSource
+    @StateObject private var dataSource: DataSource
 
     var body: some View {
         GeometryReader { geometry in
@@ -26,5 +26,9 @@ struct SplashView: View {
         .onAppear {
             dataSource.checkLogin()
         }
+    }
+
+    init(coordinator: SplashCoordinator) {
+        _dataSource = StateObject(wrappedValue: DataSource(coordinator: coordinator))
     }
 }

--- a/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/Splash/SplashView.swift
@@ -9,29 +9,22 @@
 import FlowStacks
 import SwiftUI
 
-protocol SplashCoordinator {
-
-    func showLogin()
-}
-
 struct SplashView: View {
 
-    let coordinator: SplashCoordinator
+    @StateObject var dataSource: DataSource
 
     var body: some View {
-        ZStack {
+        GeometryReader { geometry in
             Assets.background
                 .image
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .ignoresSafeArea()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(width: geometry.size.width, height: geometry.size.height)
         }
         .accessibility(.splash(.view))
         .onAppear {
-            withAnimation(.linear(duration: .fast)) {
-                coordinator.showLogin()
-            }
+            dataSource.checkLogin()
         }
     }
 }

--- a/iosApp/Survey/Sources/Supports/Helpers/KMM/AutoMockable/Shared+AutoMockable.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/KMM/AutoMockable/Shared+AutoMockable.swift
@@ -33,9 +33,8 @@ protocol LogInUseCaseKMM: LogInUseCase {
 protocol CheckLoginUseCaseKMM: CheckLoginUseCase {
 
     func invoke() -> Kotlinx_coroutines_coreFlow
-    func invokeNative()
-        -> (
-            @escaping (KotlinBoolean, KotlinUnit) -> KotlinUnit,
-            @escaping (Error?, KotlinUnit) -> KotlinUnit
-        ) -> () -> KotlinUnit
+    func invokeNative() -> (
+        @escaping (KotlinBoolean, KotlinUnit) -> KotlinUnit,
+        @escaping (Error?, KotlinUnit) -> KotlinUnit
+    ) -> () -> KotlinUnit
 }

--- a/iosApp/Survey/Sources/Supports/Helpers/KMM/AutoMockable/Shared+AutoMockable.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/KMM/AutoMockable/Shared+AutoMockable.swift
@@ -28,3 +28,14 @@ protocol LogInUseCaseKMM: LogInUseCase {
         @escaping (Error?, KotlinUnit) -> KotlinUnit
     ) -> () -> KotlinUnit
 }
+
+// sourcery: AutoMockable
+protocol CheckLoginUseCaseKMM: CheckLoginUseCase {
+
+    func invoke() -> Kotlinx_coroutines_coreFlow
+    func invokeNative()
+        -> (
+            @escaping (KotlinBoolean, KotlinUnit) -> KotlinUnit,
+            @escaping (Error?, KotlinUnit) -> KotlinUnit
+        ) -> () -> KotlinUnit
+}

--- a/iosApp/Survey/Sources/Supports/Helpers/KMM/DI/Koin/KoinApplication.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/KMM/DI/Koin/KoinApplication.swift
@@ -22,7 +22,8 @@ extension KoinApplication {
 
     private static let keyPaths: [PartialKeyPath<Koin>] = [
         \.logInViewModel,
-        \.resetPasswordViewModel
+        \.resetPasswordViewModel,
+        \.splashViewModel
     ]
 
     static func inject<T>() -> T {

--- a/iosApp/Survey/Sources/Supports/Helpers/UITests/LaunchArgument.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/UITests/LaunchArgument.swift
@@ -11,6 +11,7 @@ import Foundation
 enum LaunchArgumentKey: String {
 
     case fastAnimation
+    case clearKeychain
 }
 
 enum LaunchEnvironment {

--- a/iosApp/Survey/Sources/Supports/Helpers/UITests/UITestHelper.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/UITests/UITestHelper.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Nimble. All rights reserved.
 //
 
+import Shared
 import UIKit
 
 final class UITestHelper {
@@ -14,13 +15,17 @@ final class UITestHelper {
 
     var speed: Float = 1.0
 
-    var isRunningUITests: Bool {
+    var isFastAnimationUITests: Bool {
         LaunchArgument.contains(.fastAnimation)
+    }
+
+    var clearingKeychainUITests: Bool {
+        LaunchArgument.contains(.clearKeychain)
     }
 
     func speedUpUITestAnimation() {
         #if DEBUG
-            if isRunningUITests {
+            if isFastAnimationUITests {
                 // swiftformat:disable:next numberFormatting
                 speed = 1_000.0
                 UIApplication
@@ -31,6 +36,16 @@ final class UITestHelper {
                     .first { $0.isKeyWindow }?
                     .layer
                     .speed = speed
+            }
+        #endif
+    }
+
+    func clearKeychainUITest() {
+        #if DEBUG
+            if clearingKeychainUITests {
+                DispatchQueue.main.async {
+                    UITestLogout.shared.logOut()
+                }
             }
         #endif
     }

--- a/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
+++ b/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
@@ -97,7 +97,7 @@ final class SplashViewDataSourceSpec: QuickSpec {
                         checkLoginUseCase.invokeReturnValue = WrappedFlow.shared.bool(
                             errorMessage: "error"
                         )
-                        dataSource.checkLogin()
+                        delayCheckLogin()
                     }
 
                     it("sets loading false") {

--- a/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
+++ b/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
@@ -1,0 +1,128 @@
+//
+//  SplashViewDataSourceSpec.swift
+//  Survey
+//
+//  Created by Bliss on 12/12/22.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Nimble
+import Quick
+import Shared
+
+@testable import Survey
+
+final class SplashViewDataSourceSpec: QuickSpec {
+
+    // swiftlint:disable function_body_length
+    override func spec() {
+
+        var checkLoginUseCase: CheckLoginUseCaseKMMMock!
+        var splashViewModel: SplashViewModel!
+        var dataSource: SplashView.DataSource!
+        var coordinator: SplashCoordinatorMock!
+
+        describe("a Splash View Data Source") {
+
+            beforeEach {
+                checkLoginUseCase = CheckLoginUseCaseKMMMock()
+                splashViewModel = SplashViewModel(
+                    checkLoginUseCase: checkLoginUseCase
+                )
+                coordinator = SplashCoordinatorMock()
+                dataSource = .init(
+                    viewModel: splashViewModel,
+                    coordinator: coordinator
+                )
+            }
+
+            describe("its init") {
+
+                it("loading state is false") {
+                    let viewState = dataSource.viewState
+                    expect(viewState.isLoading) == false
+                }
+
+                it("login state is false") {
+                    let viewState = dataSource.viewState
+                    expect(viewState.isLogin) == false
+                }
+            }
+
+            describe("its checkLogin") {
+
+                context("when checkLoginUseCase returns true") {
+
+                    beforeEach {
+                        checkLoginUseCase.invokeReturnValue = WrappedFlow.shared.bool(bool: true)
+                        dataSource.checkLogin()
+                    }
+
+                    it("sets loading true") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(1)).last
+                        expect(viewState?.isLoading) == true
+                    }
+
+                    it("sets loading false") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        expect(viewState?.isLoading) == false
+                    }
+
+                    it("sets login true") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        expect(viewState?.isLogin) == true
+                    }
+                }
+
+                context("when checkLoginUseCase returns false") {
+
+                    beforeEach {
+                        checkLoginUseCase.invokeReturnValue = WrappedFlow.shared.bool(bool: false)
+                        dataSource.checkLogin()
+                    }
+
+                    it("sets loading true") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(1)).last
+                        expect(viewState?.isLoading) == true
+                    }
+
+                    it("sets loading false") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        expect(viewState?.isLoading) == false
+                    }
+
+                    it("sets login false") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        expect(viewState?.isLogin) == false
+                    }
+                }
+
+                context("when it return failure") {
+
+                    let error = "iOS_Error"
+                    beforeEach {
+                        checkLoginUseCase.invokeReturnValue = WrappedFlow.shared.bool(
+                            errorMessage: error
+                        )
+                        dataSource.checkLogin()
+                    }
+
+                    it("sets loading true") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(1)).last
+                        expect(viewState?.isLoading) == true
+                    }
+
+                    it("sets loading false") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        expect(viewState?.isLoading) == false
+                    }
+
+                    it("sets login false") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        expect(viewState?.isLogin) == false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
+++ b/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
@@ -39,13 +39,13 @@ final class SplashViewDataSourceSpec: QuickSpec {
             describe("its init") {
 
                 it("loading state is false") {
-                    let viewState = dataSource.viewState
-                    expect(viewState.isLoading) == false
+                    let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(1)).last
+                    expect(viewState?.isLoading) == false
                 }
 
                 it("login state is false") {
-                    let viewState = dataSource.viewState
-                    expect(viewState.isLogin) == false
+                    let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(1)).last
+                    expect(viewState?.isLogin) == false
                 }
             }
 
@@ -59,17 +59,17 @@ final class SplashViewDataSourceSpec: QuickSpec {
                     }
 
                     it("sets loading true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(1)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(2)).last
                         expect(viewState?.isLoading) == true
                     }
 
                     it("sets loading false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
                         expect(viewState?.isLoading) == false
                     }
 
                     it("sets login true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
                         expect(viewState?.isLogin) == true
                     }
                 }
@@ -82,17 +82,17 @@ final class SplashViewDataSourceSpec: QuickSpec {
                     }
 
                     it("sets loading true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(1)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(2)).last
                         expect(viewState?.isLoading) == true
                     }
 
                     it("sets loading false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
                         expect(viewState?.isLoading) == false
                     }
 
                     it("sets login false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
                         expect(viewState?.isLogin) == false
                     }
                 }
@@ -108,17 +108,17 @@ final class SplashViewDataSourceSpec: QuickSpec {
                     }
 
                     it("sets loading true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(1)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(2)).last
                         expect(viewState?.isLoading) == true
                     }
 
                     it("sets loading false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
                         expect(viewState?.isLoading) == false
                     }
 
                     it("sets login false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
                         expect(viewState?.isLogin) == false
                     }
                 }

--- a/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
+++ b/iosApp/SurveyTests/Sources/Specs/Presentation/Modules/SplashView/SplashViewDataSourceSpec.swift
@@ -14,7 +14,6 @@ import Shared
 
 final class SplashViewDataSourceSpec: QuickSpec {
 
-    // swiftlint:disable function_body_length
     override func spec() {
 
         var checkLoginUseCase: CheckLoginUseCaseKMMMock!
@@ -55,21 +54,21 @@ final class SplashViewDataSourceSpec: QuickSpec {
 
                     beforeEach {
                         checkLoginUseCase.invokeReturnValue = WrappedFlow.shared.bool(bool: true)
-                        dataSource.checkLogin()
+                        delayCheckLogin()
                     }
 
-                    it("sets loading true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(2)).last
+                    it("sets loading state") {
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(1)).last
                         expect(viewState?.isLoading) == true
                     }
 
                     it("sets loading false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
                         expect(viewState?.isLoading) == false
                     }
 
                     it("sets login true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
                         expect(viewState?.isLogin) == true
                     }
                 }
@@ -78,50 +77,45 @@ final class SplashViewDataSourceSpec: QuickSpec {
 
                     beforeEach {
                         checkLoginUseCase.invokeReturnValue = WrappedFlow.shared.bool(bool: false)
-                        dataSource.checkLogin()
-                    }
-
-                    it("sets loading true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(2)).last
-                        expect(viewState?.isLoading) == true
+                        delayCheckLogin()
                     }
 
                     it("sets loading false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
                         expect(viewState?.isLoading) == false
                     }
 
                     it("sets login false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
                         expect(viewState?.isLogin) == false
                     }
                 }
 
                 context("when it return failure") {
 
-                    let error = "iOS_Error"
                     beforeEach {
                         checkLoginUseCase.invokeReturnValue = WrappedFlow.shared.bool(
-                            errorMessage: error
+                            errorMessage: "error"
                         )
                         dataSource.checkLogin()
                     }
 
-                    it("sets loading true") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(2)).last
-                        expect(viewState?.isLoading) == true
-                    }
-
                     it("sets loading false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
                         expect(viewState?.isLoading) == false
                     }
 
                     it("sets login false") {
-                        let viewState = try self.awaitPublisher(dataSource.$viewState.coldCollectNext(3)).last
+                        let viewState = try self.awaitPublisher(dataSource.$viewState.collectNext(2)).last
                         expect(viewState?.isLogin) == false
                     }
                 }
+            }
+        }
+
+        func delayCheckLogin() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                dataSource.checkLogin()
             }
         }
     }

--- a/iosApp/SurveyTests/Sources/Specs/Supports/Extensions/Combine/Combine+Collect.swift
+++ b/iosApp/SurveyTests/Sources/Specs/Supports/Extensions/Combine/Combine+Collect.swift
@@ -19,4 +19,10 @@ extension Published.Publisher {
             .first()
             .eraseToAnyPublisher()
     }
+
+    func coldCollectNext(_ count: Int) -> AnyPublisher<[Output], Never> {
+        collect(count)
+            .first()
+            .eraseToAnyPublisher()
+    }
 }

--- a/iosApp/SurveyUITests/Sources/Utilities/Extensions/XCTest/ArgumentedXCUIApplication.swift
+++ b/iosApp/SurveyUITests/Sources/Utilities/Extensions/XCTest/ArgumentedXCUIApplication.swift
@@ -12,25 +12,12 @@ final class ArgumentedXCUIApplication: XCUIApplication {
 
     override init() {
         super.init()
-        isFastAnimation = true
+        add(launchArguments: .fastAnimation)
+        add(launchArguments: .clearKeychain)
     }
 }
 
 extension ArgumentedXCUIApplication {
-
-    var isFastAnimation: Bool {
-        get {
-            LaunchArgument.contains(.fastAnimation)
-        }
-
-        set {
-            if newValue {
-                add(launchArguments: .fastAnimation)
-            } else {
-                remove(launchArguments: .fastAnimation)
-            }
-        }
-    }
 
     func add(launchArguments argument: LaunchArgumentKey) {
         launchArguments.append(argument.rawValue)

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/repository/AuthenticationRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/repository/AuthenticationRepositoryImpl.kt
@@ -7,6 +7,7 @@ import co.nimblehq.blisskmmic.data.network.target.LoginTargetType
 import co.nimblehq.blisskmmic.domain.model.Token
 import co.nimblehq.blisskmmic.domain.repository.AuthenticationRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
 class AuthenticationRepositoryImpl(
@@ -27,6 +28,12 @@ class AuthenticationRepositoryImpl(
     override fun getCachedToken(): Flow<Token> {
         return localDataSource.getToken()
             .map { it.toToken() }
+    }
+
+    override fun hasCachedToken(): Flow<Boolean> {
+        return localDataSource.getToken()
+            .map { true }
+            .catch { emit(false) }
     }
 
     fun save(token: Token) {

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/extensions/Start.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/extensions/Start.kt
@@ -3,6 +3,7 @@ package co.nimblehq.blisskmmic.di.koin.extensions
 import co.nimblehq.blisskmmic.di.koin.initKoin
 import co.nimblehq.blisskmmic.presentation.modules.login.LoginViewModel
 import co.nimblehq.blisskmmic.presentation.modules.resetpassword.ResetPasswordViewModel
+import co.nimblehq.blisskmmic.presentation.modules.splash.SplashViewModel
 import org.koin.core.Koin
 import org.koin.core.KoinApplication
 
@@ -11,4 +12,6 @@ fun KoinApplication.Companion.start(): KoinApplication = initKoin()
 val Koin.logInViewModel: LoginViewModel
     get() = get()
 val Koin.resetPasswordViewModel: ResetPasswordViewModel
+    get() = get()
+val Koin.splashViewModel: SplashViewModel
     get() = get()

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/UseCaseModule.kt
@@ -1,15 +1,11 @@
 package co.nimblehq.blisskmmic.di.koin.modules
 
-import co.nimblehq.blisskmmic.domain.usecase.LogInUseCase
-import co.nimblehq.blisskmmic.domain.usecase.LogInUseCaseImpl
-import co.nimblehq.blisskmmic.domain.usecase.ResetPasswordUseCase
-import co.nimblehq.blisskmmic.domain.usecase.ResetPasswordUseCaseImpl
-import co.nimblehq.blisskmmic.domain.usecase.SurveyListUseCase
-import co.nimblehq.blisskmmic.domain.usecase.SurveyListUseCaseImpl
+import co.nimblehq.blisskmmic.domain.usecase.*
 import org.koin.dsl.module
 
 val useCaseModule = module {
     single<LogInUseCase> { LogInUseCaseImpl(get()) }
     single<ResetPasswordUseCase> { ResetPasswordUseCaseImpl(get()) }
     single<SurveyListUseCase> { SurveyListUseCaseImpl(get()) }
+    single<CheckLoginUseCase> { CheckLoginUseCaseImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/ViewModelModule.kt
@@ -2,6 +2,7 @@ package co.nimblehq.blisskmmic.di.koin.modules
 
 import co.nimblehq.blisskmmic.presentation.modules.login.LoginViewModel
 import co.nimblehq.blisskmmic.presentation.modules.resetpassword.ResetPasswordViewModel
+import co.nimblehq.blisskmmic.presentation.modules.splash.SplashViewModel
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
@@ -9,4 +10,5 @@ val viewModelModule = module {
 
     singleOf(::LoginViewModel)
     singleOf(::ResetPasswordViewModel)
+    singleOf(::SplashViewModel)
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/repository/AuthenticationRepository.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/repository/AuthenticationRepository.kt
@@ -7,4 +7,5 @@ interface AuthenticationRepository {
 
     fun logIn(email: String,  password: String): Flow<Token>
     fun getCachedToken(): Flow<Token>
+    fun hasCachedToken(): Flow<Boolean>
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/usecase/CheckLoginUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/usecase/CheckLoginUseCase.kt
@@ -1,0 +1,18 @@
+package co.nimblehq.blisskmmic.domain.usecase
+
+import co.nimblehq.blisskmmic.domain.repository.AuthenticationRepository
+import kotlinx.coroutines.flow.Flow
+
+interface CheckLoginUseCase {
+
+    operator fun invoke(): Flow<Boolean>
+}
+
+class CheckLoginUseCaseImpl(
+    private val authenticationRepository: AuthenticationRepository,
+): CheckLoginUseCase {
+
+    override operator fun invoke(): Flow<Boolean> {
+        return authenticationRepository.hasCachedToken()
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
@@ -1,11 +1,23 @@
 package co.nimblehq.blisskmmic.helpers.extensions.ios
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 
 // For iOS Unit Test
 class AnyFlow<T>(source: Flow<T>): Flow<T> by source {
 
     constructor(result: T) : this(flow { emit(result) })
     constructor(errorMessage: String) : this(flow { error(errorMessage) })
+}
+
+object WrappedFlow {
+
+    fun bool(bool: Boolean): Flow<Boolean> {
+        return flowOf(bool)
+    }
+    fun bool(errorMessage: String): Flow<Boolean> {
+        return flow { error(errorMessage) }
+    }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
@@ -1,52 +1,23 @@
 package co.nimblehq.blisskmmic.helpers.extensions.ios
 
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
-const val anyFlowDefaultDelay: Long = 50
-
 // For iOS Unit Test
 class AnyFlow<T>(source: Flow<T>): Flow<T> by source {
-    constructor(result: T, delay: Long) :
-        this(flow {
-            delay(delay)
-            emit(result)
-        })
 
-    constructor(errorMessage: String, delay: Long) :
-        this(flow {
-            delay(delay)
-            error(errorMessage)
-        })
-    
-    constructor(result: T) : this(result, anyFlowDefaultDelay)
-    constructor(errorMessage: String) : this(errorMessage, anyFlowDefaultDelay)
+    constructor(result: T) : this(flow { emit(result) })
+    constructor(errorMessage: String) : this(flow { error(errorMessage) })
 }
 
 object WrappedFlow {
 
-    fun bool(bool: Boolean, delay: Long = 50): Flow<Boolean> {
-        return flow {
-            delay(delay)
-            emit(bool)
-        }
-    }
-
-    fun bool(errorMessage: String, delay: Long = 50): Flow<Boolean> {
-        return flow {
-            delay(delay)
-            error(errorMessage)
-        }
-    }
-
     fun bool(bool: Boolean): Flow<Boolean> {
-        return bool(bool, anyFlowDefaultDelay)
+        return flowOf(bool)
     }
-
     fun bool(errorMessage: String): Flow<Boolean> {
-        return bool(errorMessage, anyFlowDefaultDelay)
+        return flow { error(errorMessage) }
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
@@ -1,23 +1,52 @@
 package co.nimblehq.blisskmmic.helpers.extensions.ios
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
+const val anyFlowDefaultDelay: Long = 50
+
 // For iOS Unit Test
 class AnyFlow<T>(source: Flow<T>): Flow<T> by source {
+    constructor(result: T, delay: Long) :
+        this(flow {
+            delay(delay)
+            emit(result)
+        })
 
-    constructor(result: T) : this(flow { emit(result) })
-    constructor(errorMessage: String) : this(flow { error(errorMessage) })
+    constructor(errorMessage: String, delay: Long) :
+        this(flow {
+            delay(delay)
+            error(errorMessage)
+        })
+    
+    constructor(result: T) : this(result, anyFlowDefaultDelay)
+    constructor(errorMessage: String) : this(errorMessage, anyFlowDefaultDelay)
 }
 
 object WrappedFlow {
 
-    fun bool(bool: Boolean): Flow<Boolean> {
-        return flowOf(bool)
+    fun bool(bool: Boolean, delay: Long = 50): Flow<Boolean> {
+        return flow {
+            delay(delay)
+            emit(bool)
+        }
     }
+
+    fun bool(errorMessage: String, delay: Long = 50): Flow<Boolean> {
+        return flow {
+            delay(delay)
+            error(errorMessage)
+        }
+    }
+
+    fun bool(bool: Boolean): Flow<Boolean> {
+        return bool(bool, anyFlowDefaultDelay)
+    }
+
     fun bool(errorMessage: String): Flow<Boolean> {
-        return flow { error(errorMessage) }
+        return bool(errorMessage, anyFlowDefaultDelay)
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/AnyFlow.kt
@@ -1,23 +1,40 @@
 package co.nimblehq.blisskmmic.helpers.extensions.ios
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 
+private const val FLOW_DELAY: Long = 50
+
 // For iOS Unit Test
 class AnyFlow<T>(source: Flow<T>): Flow<T> by source {
 
-    constructor(result: T) : this(flow { emit(result) })
-    constructor(errorMessage: String) : this(flow { error(errorMessage) })
+    constructor(result: T) :
+        this(flow {
+            delay(FLOW_DELAY)
+            emit(result)
+        })
+    constructor(errorMessage: String) :
+        this(flow {
+            delay(FLOW_DELAY)
+            error(errorMessage)
+        })
 }
 
 object WrappedFlow {
 
     fun bool(bool: Boolean): Flow<Boolean> {
-        return flowOf(bool)
+        return flow {
+            delay(FLOW_DELAY)
+            emit(bool)
+        }
     }
     fun bool(errorMessage: String): Flow<Boolean> {
-        return flow { error(errorMessage) }
+        return flow {
+            delay(FLOW_DELAY)
+            error(errorMessage)
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/UITestLogout.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/helpers/extensions/ios/UITestLogout.kt
@@ -1,0 +1,15 @@
+package co.nimblehq.blisskmmic.helpers.extensions.ios
+
+import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSourceImpl
+import com.russhwolf.settings.Settings
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+object UITestLogout: KoinComponent {
+
+    fun logOut() {
+        // TODO: Use logout use case to clear
+        val settings : Settings by inject()
+        settings.clear()
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModel.kt
@@ -5,7 +5,7 @@ import co.nimblehq.blisskmmic.presentation.modules.BaseViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
-data class SplashViewModelViewState(
+data class SplashViewState(
     val isLogin: Boolean = false,
     val isLoading: Boolean = false
 ) {
@@ -15,10 +15,10 @@ data class SplashViewModelViewState(
 class SplashViewModel(private val checkLoginUseCase: CheckLoginUseCase) :
     BaseViewModel() {
 
-    private val mutableViewState: MutableStateFlow<SplashViewModelViewState> =
-        MutableStateFlow(SplashViewModelViewState())
+    private val mutableViewState: MutableStateFlow<SplashViewState> =
+        MutableStateFlow(SplashViewState())
 
-    val viewState: StateFlow<SplashViewModelViewState> = mutableViewState
+    val viewState: StateFlow<SplashViewState> = mutableViewState
 
     fun checkLogin() {
         setStateLoading()
@@ -31,13 +31,13 @@ class SplashViewModel(private val checkLoginUseCase: CheckLoginUseCase) :
 
     private fun setStateLoading() {
         mutableViewState.update {
-            SplashViewModelViewState(isLoading = true)
+            SplashViewState(isLoading = true)
         }
     }
 
     private fun setState(login: Boolean) {
         mutableViewState.update {
-            SplashViewModelViewState(login, false)
+            SplashViewState(login, false)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModel.kt
@@ -1,0 +1,43 @@
+package co.nimblehq.blisskmmic.presentation.modules.splash
+
+import co.nimblehq.blisskmmic.domain.usecase.CheckLoginUseCase
+import co.nimblehq.blisskmmic.presentation.modules.BaseViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+data class SplashViewModelViewState(
+    val isLogin: Boolean = false,
+    val isLoading: Boolean = false
+) {
+    constructor() : this(false)
+}
+
+class SplashViewModel(private val checkLoginUseCase: CheckLoginUseCase) :
+    BaseViewModel() {
+
+    private val mutableViewState: MutableStateFlow<SplashViewModelViewState> =
+        MutableStateFlow(SplashViewModelViewState())
+
+    val viewState: StateFlow<SplashViewModelViewState> = mutableViewState
+
+    fun checkLogin() {
+        setStateLoading()
+        viewModelScope.launch {
+            checkLoginUseCase()
+                .catch { _ -> setState(false) }
+                .collect{ setState(it) }
+        }
+    }
+
+    private fun setStateLoading() {
+        mutableViewState.update {
+            SplashViewModelViewState(isLoading = true)
+        }
+    }
+
+    private fun setState(login: Boolean) {
+        mutableViewState.update {
+            SplashViewModelViewState(login, false)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/repository/AuthenticationRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/repository/AuthenticationRepositoryTest.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.blisskmmic.data.repository
 
+import app.cash.turbine.test
 import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSource
 import co.nimblehq.blisskmmic.data.database.model.TokenDatabaseModel
 import co.nimblehq.blisskmmic.data.network.datasource.NetworkDataSource
@@ -8,6 +9,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.kodein.mock.Fake
 import org.kodein.mock.Mock
@@ -112,6 +114,34 @@ class AuthenticationRepositoryTest: TestsWithMocks() {
             .getCachedToken()
             .collect {
                 it shouldBe token.toToken()
+            }
+    }
+
+    @Test
+    fun `When calling hasCachedToken, it returns true when there is a token`() = runTest {
+        mocker.every {
+            localDataSource.getToken()
+        } returns flowOf(tokenDB)
+
+        authenticationRepository
+            .hasCachedToken()
+            .test {
+                awaitItem() shouldBe true
+                awaitComplete()
+            }
+    }
+
+    @Test
+    fun `When calling hasCachedToken, it returns false when there is an error`() = runTest {
+        mocker.every {
+            localDataSource.getToken()
+        } returns flow { error("No token") }
+
+        authenticationRepository
+            .hasCachedToken()
+            .test {
+                awaitItem() shouldBe false
+                awaitComplete()
             }
     }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/domain/usecase/CheckLoginUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/domain/usecase/CheckLoginUseCaseTest.kt
@@ -1,0 +1,66 @@
+package co.nimblehq.blisskmmic.domain.usecase
+
+import app.cash.turbine.test
+import co.nimblehq.blisskmmic.domain.repository.AuthenticationRepository
+import co.nimblehq.blisskmmic.domain.repository.MockAuthenticationRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mocker
+import org.kodein.mock.UsesMocks
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@UsesMocks(AuthenticationRepository::class)
+@ExperimentalCoroutinesApi
+class CheckLoginUseCaseTest {
+
+    private val mocker = Mocker()
+    private val authenticationRepository = MockAuthenticationRepository(mocker)
+    private val checkLoginUseCase = CheckLoginUseCaseImpl(authenticationRepository)
+
+    @BeforeTest
+    fun setUp() {
+        mocker.reset()
+    }
+
+    @Test
+    fun `When calling check with response true, it returns true`() = runTest {
+        mocker.every {
+            authenticationRepository.hasCachedToken()
+        } returns flowOf(true)
+
+        checkLoginUseCase()
+            .test {
+                awaitItem() shouldBe true
+                awaitComplete()
+            }
+    }
+
+    @Test
+    fun `When calling check with response false, it returns false`() = runTest {
+        mocker.every {
+            authenticationRepository.hasCachedToken()
+        } returns flowOf(false)
+
+        checkLoginUseCase()
+            .test {
+                awaitItem() shouldBe false
+                awaitComplete()
+            }
+    }
+
+    @Test
+    fun `When calling check with a failure response, it returns correct error`() = runTest {
+        mocker.every {
+            authenticationRepository.hasCachedToken()
+        } returns flow { error("Fail") }
+
+        checkLoginUseCase()
+            .test {
+                awaitError().message shouldBe "Fail"
+            }
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/constant/TestConstants.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/constant/TestConstants.kt
@@ -1,3 +1,0 @@
-package co.nimblehq.blisskmmic.helpers.constant
-
-const val FLOW_DELAY: Long = 50

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/constant/TestConstants.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/constant/TestConstants.kt
@@ -1,3 +1,3 @@
 package co.nimblehq.blisskmmic.helpers.constant
 
-const val FlowDelay: Long = 50
+const val FLOW_DELAY: Long = 50

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/constant/TestConstants.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/constant/TestConstants.kt
@@ -1,0 +1,3 @@
+package co.nimblehq.blisskmmic.helpers.constant
+
+const val FlowDelay: Long = 50

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/flow/DelayFlowOf.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/helpers/flow/DelayFlowOf.kt
@@ -1,0 +1,17 @@
+package co.nimblehq.blisskmmic.helpers.flow
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+private const val FLOW_DELAY: Long = 50
+
+fun <T> delayFlowOf(value: T) = flow {
+    delay(FLOW_DELAY)
+    emit(value)
+}
+
+fun <T> delayFlowOf(error: String): Flow<T> = flow {
+    delay(FLOW_DELAY)
+    error(error)
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
@@ -2,7 +2,7 @@ package co.nimblehq.blisskmmic.presentation.modules.splash
 
 import app.cash.turbine.test
 import co.nimblehq.blisskmmic.domain.usecase.CheckLoginUseCase
-import co.nimblehq.blisskmmic.helpers.constant.FlowDelay
+import co.nimblehq.blisskmmic.helpers.constant.FLOW_DELAY
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -67,7 +67,7 @@ class SplashViewModelTest : TestsWithMocks() {
         mocker.every {
             checkLoginUseCase()
         } returns flow{
-            delay(FlowDelay)
+            delay(FLOW_DELAY)
             emit(false)
         }
 
@@ -89,7 +89,7 @@ class SplashViewModelTest : TestsWithMocks() {
         mocker.every {
             checkLoginUseCase()
         } returns flow {
-            delay(FlowDelay)
+            delay(FLOW_DELAY)
             error("Error")
         }
 

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
@@ -30,7 +30,8 @@ class SplashViewModelTest : TestsWithMocks() {
     lateinit var checkLoginUseCase: CheckLoginUseCase
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")
-    
+    private val delay: Long = 50
+
     private val splashViewModel by withMocks { SplashViewModel(checkLoginUseCase) }
 
     override fun setUpMocks() = injectMocks(mocker)
@@ -71,7 +72,7 @@ class SplashViewModelTest : TestsWithMocks() {
         mocker.every {
             checkLoginUseCase()
         } returns flow{
-            delay(100)
+            delay(delay)
             emit(false)
         }
 
@@ -93,7 +94,7 @@ class SplashViewModelTest : TestsWithMocks() {
         mocker.every {
             checkLoginUseCase()
         } returns flow {
-            delay(100)
+            delay(delay)
             error("Error")
         }
 

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
@@ -2,13 +2,10 @@ package co.nimblehq.blisskmmic.presentation.modules.splash
 
 import app.cash.turbine.test
 import co.nimblehq.blisskmmic.domain.usecase.CheckLoginUseCase
-import co.nimblehq.blisskmmic.helpers.constant.FLOW_DELAY
+import co.nimblehq.blisskmmic.helpers.flow.delayFlowOf
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -47,7 +44,7 @@ class SplashViewModelTest : TestsWithMocks() {
     fun `When calling checkLogin with true response, it changes viewState correctly`() = runTest {
         mocker.every {
             checkLoginUseCase()
-        } returns flowOf(true)
+        } returns delayFlowOf(true)
 
         splashViewModel.checkLogin()
 
@@ -66,10 +63,7 @@ class SplashViewModelTest : TestsWithMocks() {
     fun `When calling checkLogin with false response, it changes viewState correctly`() = runTest {
         mocker.every {
             checkLoginUseCase()
-        } returns flow{
-            delay(FLOW_DELAY)
-            emit(false)
-        }
+        } returns delayFlowOf(false)
 
         splashViewModel.checkLogin()
 
@@ -88,10 +82,7 @@ class SplashViewModelTest : TestsWithMocks() {
     fun `When calling checkLogin with faliure response, it changes viewState correctly`() = runTest {
         mocker.every {
             checkLoginUseCase()
-        } returns flow {
-            delay(FLOW_DELAY)
-            error("Error")
-        }
+        } returns delayFlowOf("Error")
 
         splashViewModel.checkLogin()
 

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
@@ -1,16 +1,12 @@
 package co.nimblehq.blisskmmic.presentation.modules.splash
 
 import app.cash.turbine.test
-import app.cash.turbine.testIn
-import co.nimblehq.blisskmmic.MR
 import co.nimblehq.blisskmmic.domain.usecase.CheckLoginUseCase
-import co.nimblehq.blisskmmic.domain.usecase.ResetPasswordUseCase
-import co.nimblehq.blisskmmic.presentation.modules.resetpassword.ResetPasswordViewModel
+import co.nimblehq.blisskmmic.helpers.constant.FlowDelay
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.newSingleThreadContext
@@ -30,7 +26,6 @@ class SplashViewModelTest : TestsWithMocks() {
     lateinit var checkLoginUseCase: CheckLoginUseCase
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")
-    private val delay: Long = 50
 
     private val splashViewModel by withMocks { SplashViewModel(checkLoginUseCase) }
 
@@ -72,7 +67,7 @@ class SplashViewModelTest : TestsWithMocks() {
         mocker.every {
             checkLoginUseCase()
         } returns flow{
-            delay(delay)
+            delay(FlowDelay)
             emit(false)
         }
 
@@ -94,7 +89,7 @@ class SplashViewModelTest : TestsWithMocks() {
         mocker.every {
             checkLoginUseCase()
         } returns flow {
-            delay(delay)
+            delay(FlowDelay)
             error("Error")
         }
 

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/splash/SplashViewModelTest.kt
@@ -1,0 +1,112 @@
+package co.nimblehq.blisskmmic.presentation.modules.splash
+
+import app.cash.turbine.test
+import app.cash.turbine.testIn
+import co.nimblehq.blisskmmic.MR
+import co.nimblehq.blisskmmic.domain.usecase.CheckLoginUseCase
+import co.nimblehq.blisskmmic.domain.usecase.ResetPasswordUseCase
+import co.nimblehq.blisskmmic.presentation.modules.resetpassword.ResetPasswordViewModel
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Mock
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class SplashViewModelTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var checkLoginUseCase: CheckLoginUseCase
+
+    private val mainThreadSurrogate = newSingleThreadContext("UI thread")
+    
+    private val splashViewModel by withMocks { SplashViewModel(checkLoginUseCase) }
+
+    override fun setUpMocks() = injectMocks(mocker)
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(mainThreadSurrogate)
+        mocker.reset()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        mainThreadSurrogate.close()
+    }
+
+    @Test
+    fun `When calling checkLogin with true response, it changes viewState correctly`() = runTest {
+        mocker.every {
+            checkLoginUseCase()
+        } returns flowOf(true)
+
+        splashViewModel.checkLogin()
+
+        splashViewModel
+            .viewState
+            .test {
+                awaitItem().isLoading shouldBe true
+                val result = awaitItem()
+                result.isLogin shouldBe true
+                result.isLoading shouldBe false
+                cancel()
+            }
+    }
+
+    @Test
+    fun `When calling checkLogin with false response, it changes viewState correctly`() = runTest {
+        mocker.every {
+            checkLoginUseCase()
+        } returns flow{
+            delay(100)
+            emit(false)
+        }
+
+        splashViewModel.checkLogin()
+
+        splashViewModel
+            .viewState
+            .test {
+                awaitItem().isLoading shouldBe true
+                val result = awaitItem()
+                result.isLogin shouldBe false
+                result.isLoading shouldBe false
+                cancel()
+            }
+    }
+
+    @Test
+    fun `When calling checkLogin with faliure response, it changes viewState correctly`() = runTest {
+        mocker.every {
+            checkLoginUseCase()
+        } returns flow {
+            delay(100)
+            error("Error")
+        }
+
+        splashViewModel.checkLogin()
+
+        splashViewModel
+            .viewState
+            .test {
+                awaitItem().isLoading shouldBe true
+                val result = awaitItem()
+                result.isLogin shouldBe false
+                result.isLoading shouldBe false
+                cancel()
+            }
+    }
+}


### PR DESCRIPTION
- close #62 

## What happened

iOS app starts with login screen when not login and home loading when logged in.
 
## Insight

- Add `CheckLogInUseCase`.
- Add `SplashViewModel`.
- Add `SplashViewDataSource`.
- Add flag for UITest to clear token.
- Most line changes are Unit test.
 
## Proof Of Work

Logged in:


https://user-images.githubusercontent.com/6356137/207005933-45cc5cdc-61c9-497c-81f1-3d5e3f3d68fc.mp4



Not logged in:

https://user-images.githubusercontent.com/6356137/207006066-466d5278-c634-407d-b972-1a052afaafa9.mp4


