### PR TITLE
[#44] [#43] [Integrate] [Backend] As a user, I can refresh my token when it's expired

### DIFF
--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/datasource/NetworkDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/datasource/NetworkDataSource.kt
@@ -16,6 +16,7 @@ interface NetworkDataSource {
     fun resetPassword(target: ResetPasswordTargetType): Flow<ResetPasswordMeta>
     fun survey(target: SurveySelectionTargetType): Flow<Pair<List<SurveyApiModel>, PaginationMetaApiModel>>
     fun profile(target: UserProfileTargetType): Flow<UserApiModel>
+    fun refreshToken(target: RefreshTokenType): Flow<TokenApiModel>
 }
 
 class NetworkDataSourceImpl(private val networkClient: NetworkClient): NetworkDataSource {
@@ -34,6 +35,10 @@ class NetworkDataSourceImpl(private val networkClient: NetworkClient): NetworkDa
     }
 
     override fun profile(target: UserProfileTargetType): Flow<UserApiModel> {
+        return networkClient.fetch(target.requestBuilder())
+    }
+
+    override fun refreshToken(target: RefreshTokenType): Flow<TokenApiModel> {
         return networkClient.fetch(target.requestBuilder())
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/target/RefreshTokenType.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/network/target/RefreshTokenType.kt
@@ -1,0 +1,28 @@
+package co.nimblehq.blisskmmic.data.network.target
+
+import co.nimblehq.blisskmmic.BuildKonfig
+import co.nimblehq.blisskmmic.data.network.helpers.TargetType
+import io.ktor.http.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+class RefreshTokenType(refreshToken: String):
+    TargetType<RefreshTokenType.RefreshTokenInput> {
+
+    @Serializable
+    data class RefreshTokenInput(
+        @SerialName("grant_type") val grantType: String,
+        @SerialName("refresh_token") val refreshToken: String,
+        @SerialName("client_id") val clientId: String,
+        @SerialName("client_secret") val clientSecret: String
+    )
+
+    override val path = "oauth/token"
+    override val method = HttpMethod.Post
+    override val body = RefreshTokenInput(
+        "refresh_token",
+        refreshToken,
+        BuildKonfig.CLIENT_ID,
+        BuildKonfig.CLIENT_SECRET
+    )
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/NetworkModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/NetworkModule.kt
@@ -13,6 +13,6 @@ val networkModule = module {
     single { NetworkClient() }
     single<NetworkDataSource>(named(NETWORK_CLIENT_KOIN)) { NetworkDataSourceImpl(get()) }
     single<NetworkDataSource>(named(TOKENIZED_NETWORK_CLIENT_KOIN)) {
-        NetworkDataSourceImpl(TokenizedNetworkClient(null, get()))
+        NetworkDataSourceImpl(TokenizedNetworkClient(null, get(), get(named(NETWORK_CLIENT_KOIN))))
     }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/datasource/NetworkDataSourceTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/datasource/NetworkDataSourceTest.kt
@@ -114,4 +114,19 @@ class NetworkDataSourceTest {
                 awaitComplete()
             }
     }
+
+    // Refresh Token
+
+    @Test
+    fun `When calling refresh token with success response - it returns correct object`() = runTest {
+        val engine = jsonMockEngine(LOG_IN_JSON_RESULT, "oauth/token")
+        val networkClient = NetworkClient(engine = engine)
+        val dataSource = NetworkDataSourceImpl(networkClient)
+        dataSource
+            .refreshToken(RefreshTokenType(""))
+            .test {
+                awaitItem().refreshToken shouldBe "refresh_token"
+                awaitComplete()
+            }
+    }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClientTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/data/network/core/TokenizedNetworkClientTest.kt
@@ -5,7 +5,11 @@ import co.nimblehq.blisskmmic.BuildKonfig
 import co.nimblehq.blisskmmic.data.database.datasource.LocalDataSource
 import co.nimblehq.blisskmmic.data.database.datasource.MockLocalDataSource
 import co.nimblehq.blisskmmic.data.database.model.TokenDatabaseModel
+import co.nimblehq.blisskmmic.data.network.datasource.MockNetworkDataSource
+import co.nimblehq.blisskmmic.data.network.datasource.NetworkDataSource
 import co.nimblehq.blisskmmic.data.network.helpers.API_VERSION
+import co.nimblehq.blisskmmic.domain.model.TokenApiModel
+import co.nimblehq.blisskmmic.helpers.flow.delayFlowOf
 import co.nimblehq.blisskmmic.helpers.mock.NETWORK_META_MOCK_MODEL_RESULT
 import co.nimblehq.blisskmmic.helpers.mock.NETWORK_MOCK_MODEL_RESULT
 import co.nimblehq.blisskmmic.helpers.mock.NetworkMetaMockModel
@@ -14,7 +18,9 @@ import co.nimblehq.blisskmmic.helpers.mock.ktor.jsonTokenizedMockEngine
 import co.nimblehq.jsonapi.model.JsonApiException
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -25,14 +31,22 @@ import kotlin.test.Test
 import kotlin.test.fail
 
 @ExperimentalCoroutinesApi
-@UsesMocks(LocalDataSource::class)
+@UsesMocks(LocalDataSource::class, NetworkDataSource::class)
 class TokenizedNetworkClientTest {
 
     private val mocker = Mocker()
     private val localDataSource = MockLocalDataSource(mocker)
+    private val networkDataSource = MockNetworkDataSource(mocker)
 
     private val token = TokenDatabaseModel(
         accessToken = "Access",
+        tokenType = "",
+        expiresIn = 1,
+        refreshToken = "",
+        createdAt = 1
+    )
+    private val refreshedToken = TokenApiModel(
+        accessToken = "Refreshed Access",
         tokenType = "",
         expiresIn = 1,
         refreshToken = "",
@@ -45,6 +59,12 @@ class TokenizedNetworkClientTest {
     fun setUp() {
         mocker.reset()
         request.url("$BuildKonfig.BASE_URL$API_VERSION$path")
+        mocker.every {
+            networkDataSource.refreshToken(isAny())
+        } returns delayFlowOf(refreshedToken)
+        mocker.every {
+            localDataSource.save(isAny())
+        } returns Unit
     }
 
     @Test
@@ -54,10 +74,10 @@ class TokenizedNetworkClientTest {
         } returns flowOf(token)
         val engine = jsonTokenizedMockEngine(
             NETWORK_MOCK_MODEL_RESULT,
-            token.accessToken,
+            refreshedToken.accessToken,
             path
         )
-        val networkClient = TokenizedNetworkClient(engine = engine, localDataSource)
+        val networkClient = TokenizedNetworkClient(engine, localDataSource, networkDataSource)
         networkClient
             .fetch<NetworkMockModel>(request)
             .test {
@@ -73,10 +93,10 @@ class TokenizedNetworkClientTest {
         } returns flowOf(token)
         val engine = jsonTokenizedMockEngine(
             NETWORK_META_MOCK_MODEL_RESULT,
-            token.accessToken,
+            refreshedToken.accessToken,
             path
         )
-        val networkClient = TokenizedNetworkClient(engine = engine, localDataSource)
+        val networkClient = TokenizedNetworkClient(engine, localDataSource, networkDataSource)
         networkClient
             .fetchWithMeta<NetworkMockModel, NetworkMetaMockModel>(request)
             .test {
@@ -97,7 +117,7 @@ class TokenizedNetworkClientTest {
             "no access",
             path
         )
-        val networkClient = TokenizedNetworkClient(engine = engine, localDataSource)
+        val networkClient = TokenizedNetworkClient(engine, localDataSource, networkDataSource)
         networkClient
             .fetch<NetworkMockModel>(request)
             .test {
@@ -105,6 +125,37 @@ class TokenizedNetworkClientTest {
                     is JsonApiException -> error.errors.map { it.code } shouldContain "unauthorized"
                     else -> fail("Should not return incorrect error type")
                 }
+            }
+    }
+
+    @Test
+    fun `when receiving expired token - it calls refresh token`() = runTest {
+        mocker.every {
+            localDataSource.getToken()
+        } returns delayFlowOf(token)
+        var attempt = 0
+        val engine = MockEngine { _ ->
+            if(attempt == 0) {
+                attempt++
+                respond(
+                    NETWORK_MOCK_MODEL_RESULT,
+                    HttpStatusCode.Unauthorized,
+                    headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            } else {
+                respond(
+                    NETWORK_MOCK_MODEL_RESULT,
+                    HttpStatusCode.OK,
+                    headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+        }
+        val networkClient = TokenizedNetworkClient(engine, localDataSource, networkDataSource)
+        networkClient
+            .fetch<NetworkMockModel>(request)
+            .test {
+                awaitItem().title shouldBe "Hello"
+                awaitComplete()
             }
     }
 }


### PR DESCRIPTION
- close #43 
- close #44
Duplicate of #106 

## What happened

When API returns token expired, call `/api/v1/oauth/token` to refresh token before calling the API again.
 
## Insight

- Add `Ktor.Auth.refreshTokens`.
- Add `RefreshTokenType`.
 
## Proof Of Work


<img width="1044" alt="Screen Shot 2023-01-03 at 17 27 54" src="https://user-images.githubusercontent.com/6356137/210700754-f0792b63-9e06-453c-be9c-d805e3195832.png">
