### PR TITLE
[#28] [iOS] [Integrate] As a user, I can see Survey Detail

### DIFF
--- a/iosApp/Survey.xcodeproj/project.pbxproj
+++ b/iosApp/Survey.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		09D09E09296E7D55009F88AF /* SurveyQuestionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09E06296E7D55009F88AF /* SurveyQuestionScreen.swift */; };
 		09D09E0B296E837F009F88AF /* QuestionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09E0A296E837F009F88AF /* QuestionPickerView.swift */; };
 		09D09E0C296EBA20009F88AF /* TimeInterval+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C2F4012934588400F44818 /* TimeInterval+Constants.swift */; };
+		09E08C562990E97F00CC765C /* Collection+Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E08C552990E97F00CC765C /* Collection+Safe.swift */; };
+		09E08C5A2990EB4B00CC765C /* CollectionSafeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E08C582990EB3800CC765C /* CollectionSafeSpec.swift */; };
 		09E6ABF32951D105007F1EE3 /* KIF+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E6ABF12951D103007F1EE3 /* KIF+Swift.swift */; };
 		09E6ABFD2951D32F007F1EE3 /* ViewId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09636B1428D8148C00A5CB97 /* ViewId.swift */; };
 		09E6ABFE2951D333007F1EE3 /* ViewId+General.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09636B2F28D8267D00A5CB97 /* ViewId+General.swift */; };
@@ -319,6 +321,8 @@
 		09D09E02296E7CF9009F88AF /* SurveyQuestionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyQuestionSpec.swift; sourceTree = "<group>"; };
 		09D09E06296E7D55009F88AF /* SurveyQuestionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyQuestionScreen.swift; sourceTree = "<group>"; };
 		09D09E0A296E837F009F88AF /* QuestionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionPickerView.swift; sourceTree = "<group>"; };
+		09E08C552990E97F00CC765C /* Collection+Safe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Safe.swift"; sourceTree = "<group>"; };
+		09E08C582990EB3800CC765C /* CollectionSafeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSafeSpec.swift; sourceTree = "<group>"; };
 		09E6ABE42951CF3E007F1EE3 /* SurveyKIFUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SurveyKIFUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		09E6ABF12951D103007F1EE3 /* KIF+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KIF+Swift.swift"; sourceTree = "<group>"; };
 		09E6AC0B2951D5DD007F1EE3 /* AccountSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSpec.swift; sourceTree = "<group>"; };
@@ -1037,6 +1041,7 @@
 			isa = PBXGroup;
 			children = (
 				64ED519E814E897776076800 /* Optional+Unwrap.swift */,
+				09E08C552990E97F00CC765C /* Collection+Safe.swift */,
 				09495FCE29110E820036BDFB /* String+URL.swift */,
 			);
 			path = Foundation;
@@ -1156,6 +1161,7 @@
 			isa = PBXGroup;
 			children = (
 				D1EE1175F99D55A95E0995E9 /* OptionalUnwrapSpec.swift */,
+				09E08C582990EB3800CC765C /* CollectionSafeSpec.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -1890,6 +1896,7 @@
 			files = (
 				09D09DFD296E6B35009F88AF /* SurveyQuestionView.swift in Sources */,
 				0982A80729278E9000FC1976 /* SurveyHeaderLoading.swift in Sources */,
+				09E08C562990E97F00CC765C /* Collection+Safe.swift in Sources */,
 				09FE26D3294C1906005A7F85 /* ViewDidLoadModifier.swift in Sources */,
 				09CE772728E2C44D00EAA9EE /* View+BackButton.swift in Sources */,
 				0982A80329278E9000FC1976 /* SurveyHeaderView.swift in Sources */,
@@ -2004,6 +2011,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09A9F8F8295479CA009DE583 /* AccountViewDataSourceSpec.swift in Sources */,
+				09E08C5A2990EB4B00CC765C /* CollectionSafeSpec.swift in Sources */,
 				09C2F413293777ED00F44818 /* Combine+Collect.swift in Sources */,
 				0964B1DD2947021400946FA1 /* SplashViewDataSourceSpec.swift in Sources */,
 				5BBBFAF49689F25A8C1D57AB /* AutoMockable.generated.swift in Sources */,

--- a/iosApp/Survey.xcodeproj/project.pbxproj
+++ b/iosApp/Survey.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		0964B1D92946FA8100946FA1 /* SplashView+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1D82946FA8100946FA1 /* SplashView+DataSource.swift */; };
 		0964B1DD2947021400946FA1 /* SplashViewDataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0964B1DB2947008E00946FA1 /* SplashViewDataSourceSpec.swift */; };
 		097C4AE62987BA8900AE265A /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097C4AE52987BA8900AE265A /* BackButton.swift */; };
+		097C4AE82988B96E00AE265A /* SurveyDetailView+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097C4AE72988B96E00AE265A /* SurveyDetailView+DataSource.swift */; };
 		0982A79E2921DF7E00FC1976 /* SurveySelectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7982921DE6700FC1976 /* SurveySelectionSpec.swift */; };
 		0982A7A62921DFE800FC1976 /* ResetPasswordSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7A32921DFE700FC1976 /* ResetPasswordSpec.swift */; };
 		0982A7DF29222EA800FC1976 /* LoginSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982A7DE29222EA800FC1976 /* LoginSpec.swift */; };
@@ -117,7 +118,6 @@
 		09D09DD429682CBC009F88AF /* ViewId+SurveyDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09DBD2967EA5F009F88AF /* ViewId+SurveyDetail.swift */; };
 		09D09DD529682CBF009F88AF /* ViewId+SurveyDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09DBD2967EA5F009F88AF /* ViewId+SurveyDetail.swift */; };
 		09D09DFA296E4B85009F88AF /* ResetPasswordSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09DF9296E4B85009F88AF /* ResetPasswordSpec.swift */; };
-		09D09E0C296EBA20009F88AF /* TimeInterval+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C2F4012934588400F44818 /* TimeInterval+Constants.swift */; };
 		09D09DFD296E6B35009F88AF /* SurveyQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09DFC296E6B35009F88AF /* SurveyQuestionView.swift */; };
 		09D09DFF296E7BFD009F88AF /* ViewId+SurveyQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09DFE296E7BFD009F88AF /* ViewId+SurveyQuestion.swift */; };
 		09D09E00296E7BFD009F88AF /* ViewId+SurveyQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09DFE296E7BFD009F88AF /* ViewId+SurveyQuestion.swift */; };
@@ -125,6 +125,7 @@
 		09D09E05296E7CF9009F88AF /* SurveyQuestionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09E02296E7CF9009F88AF /* SurveyQuestionSpec.swift */; };
 		09D09E09296E7D55009F88AF /* SurveyQuestionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09E06296E7D55009F88AF /* SurveyQuestionScreen.swift */; };
 		09D09E0B296E837F009F88AF /* QuestionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D09E0A296E837F009F88AF /* QuestionPickerView.swift */; };
+		09D09E0C296EBA20009F88AF /* TimeInterval+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C2F4012934588400F44818 /* TimeInterval+Constants.swift */; };
 		09E6ABF32951D105007F1EE3 /* KIF+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E6ABF12951D103007F1EE3 /* KIF+Swift.swift */; };
 		09E6ABFD2951D32F007F1EE3 /* ViewId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09636B1428D8148C00A5CB97 /* ViewId.swift */; };
 		09E6ABFE2951D333007F1EE3 /* ViewId+General.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09636B2F28D8267D00A5CB97 /* ViewId+General.swift */; };
@@ -259,6 +260,7 @@
 		0964B1D82946FA8100946FA1 /* SplashView+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SplashView+DataSource.swift"; sourceTree = "<group>"; };
 		0964B1DB2947008E00946FA1 /* SplashViewDataSourceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewDataSourceSpec.swift; sourceTree = "<group>"; };
 		097C4AE52987BA8900AE265A /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
+		097C4AE72988B96E00AE265A /* SurveyDetailView+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SurveyDetailView+DataSource.swift"; sourceTree = "<group>"; };
 		0982A7982921DE6700FC1976 /* SurveySelectionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveySelectionSpec.swift; sourceTree = "<group>"; };
 		0982A7A32921DFE700FC1976 /* ResetPasswordSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResetPasswordSpec.swift; sourceTree = "<group>"; };
 		0982A7DE29222EA800FC1976 /* LoginSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginSpec.swift; sourceTree = "<group>"; };
@@ -880,6 +882,7 @@
 			isa = PBXGroup;
 			children = (
 				09D09DBB2967E843009F88AF /* SurveyDetailView.swift */,
+				097C4AE72988B96E00AE265A /* SurveyDetailView+DataSource.swift */,
 				09D09DC7296817E2009F88AF /* SurveyDetailImage.swift */,
 				09D09DFB296E6B24009F88AF /* SurveyQuestion */,
 			);
@@ -1937,6 +1940,7 @@
 				09636B1528D8148C00A5CB97 /* ViewId.swift in Sources */,
 				0982A80529278E9000FC1976 /* SurveyLoading.swift in Sources */,
 				0982A7E029222EB900FC1976 /* ViewId+Splash.swift in Sources */,
+				097C4AE82988B96E00AE265A /* SurveyDetailView+DataSource.swift in Sources */,
 				0964B1D02942F3A300946FA1 /* LoginView+DataSource.swift in Sources */,
 				09495F9C290A35BC0036BDFB /* ViewId+Account.swift in Sources */,
 				09CE770F28E1922000EAA9EE /* Screen.swift in Sources */,

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView+DataSource.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView+DataSource.swift
@@ -1,0 +1,69 @@
+//
+//  SurveyDetailView+DataSource.swift
+//  Survey
+//
+//  Created by Bliss on 31/1/23.
+//  Copyright © 2023 Nimble. All rights reserved.
+//
+
+import Combine
+import KMPNativeCoroutinesCombine
+import Shared
+import SwiftUI
+
+extension SurveyDetailView {
+
+    final class DataSource: ObservableObject {
+
+        let viewModel: SurveyDetailViewModel
+
+        @Published private(set) var viewState = SurveyDetailViewState()
+        @Published var isShowingErrorAlert = false
+        @Published var isLoading = false
+        @Published var isShowingTitle = true
+        @Published var isShowingTitleNavigationBar = true
+
+        private var cancellables = Set<AnyCancellable>()
+
+        init(
+            viewModel: SurveyDetailViewModel = KoinApplication.shared.inject(),
+            id: String
+        ) {
+            self.viewModel = viewModel
+            viewModel.setSurveyId(id: id)
+            viewModel.getDetail()
+
+            createPublisher(for: viewModel.viewStateNative)
+                .catch { error -> Just<SurveyDetailViewState> in
+                    let surveyDetailViewState = SurveyDetailViewState(
+                        error: error.localizedDescription
+                    )
+                    return Just(surveyDetailViewState)
+                }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] value in
+                    guard let self else { return }
+                    self.updateStates(value)
+                }
+                .store(in: &cancellables)
+        }
+
+        func didPressNext() {
+            viewModel.showQuestion()
+        }
+
+        private func updateStates(_ state: SurveyDetailViewState) {
+            viewState = state
+            isShowingErrorAlert = !state.error.string.isEmpty
+            isLoading = state.isLoading && state.isShowingQuestion
+            if state.surveyDetail != nil, state.isShowingQuestion {
+                isShowingTitleNavigationBar = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + .instant) {
+                    withAnimation(.easeIn(duration: .viewTransition)) {
+                        self.isShowingTitle = false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
@@ -71,8 +71,11 @@ struct SurveyDetailView: View {
                 surveyTitleView
                     .transition(.move(edge: .leading).combined(with: .opacity))
             } else if let surveyDetail = dataSource.viewState.surveyDetail {
-                SurveyQuestionView(detail: surveyDetail, questionIndex: $questionIndex)
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                if questionIndex.isMultiple(of: 2) {
+                    animatedSurveyQuestionView(surveyDetail: surveyDetail)
+                } else {
+                    animatedSurveyQuestionView(surveyDetail: surveyDetail)
+                }
             } else {
                 Spacer()
             }
@@ -111,7 +114,13 @@ struct SurveyDetailView: View {
                 .accessibility(.surveyDetail(.startButton))
             } else {
                 Button {
-                    questionIndex += 1
+                    // TODO: Submit button logics
+                    let totalItem = (dataSource.viewState.surveyDetail?.questions.count ?? 0) - 1
+                    guard questionIndex < totalItem
+                    else { return }
+                    withAnimation(.easeIn(duration: .viewTransition)) {
+                        questionIndex += 1
+                    }
                 } label: {
                     Assets.nextButton
                         .image
@@ -142,6 +151,16 @@ struct SurveyDetailView: View {
         self.coordinator = coordinator
         let dataSource = DataSource(id: survey.id)
         _dataSource = StateObject(wrappedValue: dataSource)
+    }
+
+    private func animatedSurveyQuestionView(surveyDetail: SurveyDetailUiModel) -> some View {
+        return SurveyQuestionView(detail: surveyDetail, questionIndex: $questionIndex)
+            .transition(
+                .asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                )
+            )
     }
 
     func didPressBack() {

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
@@ -116,8 +116,7 @@ struct SurveyDetailView: View {
                 Button {
                     // TODO: Submit button logics
                     let totalItem = (dataSource.viewState.surveyDetail?.questions.count ?? 0) - 1
-                    guard questionIndex < totalItem
-                    else { return }
+                    guard questionIndex < totalItem else { return }
                     withAnimation(.easeIn(duration: .viewTransition)) {
                         questionIndex += 1
                     }

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
@@ -71,11 +71,8 @@ struct SurveyDetailView: View {
                 surveyTitleView
                     .transition(.move(edge: .leading).combined(with: .opacity))
             } else if let surveyDetail = dataSource.viewState.surveyDetail {
-                if questionIndex.isMultiple(of: 2) {
-                    animatedSurveyQuestionView(surveyDetail: surveyDetail)
-                } else {
-                    animatedSurveyQuestionView(surveyDetail: surveyDetail)
-                }
+                animatedSurveyQuestionView(surveyDetail: surveyDetail)
+                    .id(questionIndex)
             } else {
                 Spacer()
             }

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyDetailView.swift
@@ -22,6 +22,7 @@ struct SurveyDetailView: View {
     @StateObject var dataSource: DataSource
 
     @State var isAnimating = true
+    @State var questionIndex = 0
 
     var body: some View {
         ZStack {
@@ -48,7 +49,6 @@ struct SurveyDetailView: View {
         .alert(isPresented: $dataSource.isShowingErrorAlert, content: {
             Alert(title: Text(dataSource.viewState.error))
         })
-
     }
 
     var surveyView: some View {
@@ -70,9 +70,11 @@ struct SurveyDetailView: View {
             if dataSource.isShowingTitle {
                 surveyTitleView
                     .transition(.move(edge: .leading).combined(with: .opacity))
-            } else {
-                SurveyQuestionView()
+            } else if let surveyDetail = dataSource.viewState.surveyDetail {
+                SurveyQuestionView(detail: surveyDetail, questionIndex: $questionIndex)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
+            } else {
+                Spacer()
             }
         }
     }
@@ -109,7 +111,7 @@ struct SurveyDetailView: View {
                 .accessibility(.surveyDetail(.startButton))
             } else {
                 Button {
-                    // TODO: Add action when press next
+                    questionIndex += 1
                 } label: {
                     Assets.nextButton
                         .image

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
@@ -6,26 +6,35 @@
 //  Copyright © 2023 Nimble. All rights reserved.
 //
 
+import Shared
 import SwiftUI
 
 struct SurveyQuestionView: View {
 
+    let detail: SurveyDetailUiModel
+
+    @Binding var questionIndex: Int
+
     var body: some View {
         VStack(alignment: .leading) {
-            // TODO: Use real data
-            Text("1/5")
+            Text("\(questionIndex + 1)/\(detail.questions.count)")
                 .font(.boldMedium)
                 .foregroundColor(.white)
                 .opacity(0.5)
                 .padding(.top, .largePadding)
                 .accessibility(.surveyQuestion(.detailText))
-            Text("How are you?")
+            Text(detail.questions[questionIndex].text)
                 .font(.boldLargeTitle)
                 .foregroundColor(.white)
                 .padding(.top, .tinyPadding)
                 .accessibility(.surveyQuestion(.titleText))
             Spacer()
-            QuestionPickerView(ids: ["A", "B", "C"])
+            // TODO: Show real questions
+            switch detail.questions[questionIndex].displayType {
+            case SurveyDetailUiModel.companion.Choice:
+                QuestionPickerView(ids: ["A", "B", "C"])
+            default: QuestionPickerView(ids: ["A", "B", "C"])
+            }
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
@@ -35,12 +35,12 @@ struct SurveyQuestionView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    @ViewBuilder
     func questionView(with question: SurveyDetailUiModel.SurveyIncluded) -> some View {
         // TODO: Show real questions
         switch question.displayType {
-        case SurveyDetailUiModel.companion.Choice:
-            return QuestionPickerView(ids: ["A", "B", "C"])
-        default: return QuestionPickerView(ids: ["A", "B", "C"])
+        case .choice: QuestionPickerView(ids: ["A", "B", "C"])
+        default: VStack {}
         }
     }
 }

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
@@ -29,14 +29,18 @@ struct SurveyQuestionView: View {
                 .padding(.top, .tinyPadding)
                 .accessibility(.surveyQuestion(.titleText))
             Spacer()
-            // TODO: Show real questions
-            switch detail.questions[questionIndex].displayType {
-            case SurveyDetailUiModel.companion.Choice:
-                QuestionPickerView(ids: ["A", "B", "C"])
-            default: QuestionPickerView(ids: ["A", "B", "C"])
-            }
+            questionView(with: detail.questions[questionIndex])
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    func questionView(with question: SurveyDetailUiModel.SurveyIncluded) -> some View {
+        // TODO: Show real questions
+        switch question.displayType {
+        case SurveyDetailUiModel.companion.Choice:
+            return QuestionPickerView(ids: ["A", "B", "C"])
+        default: return QuestionPickerView(ids: ["A", "B", "C"])
+        }
     }
 }

--- a/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
+++ b/iosApp/Survey/Sources/Presentation/Modules/SurveyDetail/SurveyQuestion/SurveyQuestionView.swift
@@ -23,13 +23,15 @@ struct SurveyQuestionView: View {
                 .opacity(0.5)
                 .padding(.top, .largePadding)
                 .accessibility(.surveyQuestion(.detailText))
-            Text(detail.questions[questionIndex].text)
-                .font(.boldLargeTitle)
-                .foregroundColor(.white)
-                .padding(.top, .tinyPadding)
-                .accessibility(.surveyQuestion(.titleText))
-            Spacer()
-            questionView(with: detail.questions[questionIndex])
+            if let question = detail.questions[safe: questionIndex] {
+                Text(question.text)
+                    .font(.boldLargeTitle)
+                    .foregroundColor(.white)
+                    .padding(.top, .tinyPadding)
+                    .accessibility(.surveyQuestion(.titleText))
+                Spacer()
+                questionView(with: question)
+            }
             Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/iosApp/Survey/Sources/Supports/Extensions/Foundation/Collection+Safe.swift
+++ b/iosApp/Survey/Sources/Supports/Extensions/Foundation/Collection+Safe.swift
@@ -1,0 +1,15 @@
+//
+//  Collection+Safe.swift
+//  Survey
+//
+//  Created by Bliss on 6/2/23.
+//  Copyright © 2023 Nimble. All rights reserved.
+//
+
+extension Collection {
+
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/iosApp/Survey/Sources/Supports/Helpers/KMM/DI/Koin/KoinApplication.swift
+++ b/iosApp/Survey/Sources/Supports/Helpers/KMM/DI/Koin/KoinApplication.swift
@@ -24,7 +24,8 @@ extension KoinApplication {
         \.logInViewModel,
         \.resetPasswordViewModel,
         \.splashViewModel,
-        \.surveySelectionViewModel
+        \.surveySelectionViewModel,
+        \.surveyDetailViewModel
     ]
 
     static func inject<T>() -> T {

--- a/iosApp/SurveyTests/Sources/Specs/Supports/Extensions/Foundation/CollectionSafeSpec.swift
+++ b/iosApp/SurveyTests/Sources/Specs/Supports/Extensions/Foundation/CollectionSafeSpec.swift
@@ -1,0 +1,42 @@
+//
+//  CollectionSafeSpec.swift
+//  SurveyTests
+//
+//  Created by Bliss on 6/2/23.
+//  Copyright © 2023 Nimble. All rights reserved.
+//
+
+import Nimble
+import Quick
+
+@testable import Survey
+
+final class CollectionSafeSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("a string array") {
+            var values: [String]!
+
+            context("when there is 1 value") {
+                beforeEach {
+                    values = ["hello"]
+                }
+
+                context("when getting value at index 0 with safe") {
+
+                    it("returns correct value") {
+                        expect(values[safe: 0]) == "hello"
+                    }
+                }
+
+                context("when getting value at index 1 with safe") {
+
+                    it("returns nil") {
+                        expect(values[safe: 1]) == nil
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/model/SurveyDetailApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/model/SurveyDetailApiModel.kt
@@ -35,9 +35,9 @@ data class SurveyDetailApiModel(
     @Serializable
     data class SurveyAnswer(
         val id: String,
-        val text: String,
+        val text: String?,
         @SerialName("display_order") val displayOrder: Int,
-        @SerialName("input_mask_placeholder") val inputMaskPlaceholder: String
+        @SerialName("input_mask_placeholder") val inputMaskPlaceholder: String?
     ) {
         fun toSurveyDetail(): SurveyDetail.SurveyAnswer = SurveyDetail.SurveyAnswer(
             id,

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/model/SurveyDetailApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/data/model/SurveyDetailApiModel.kt
@@ -17,14 +17,41 @@ data class SurveyDetailApiModel(
 
     @Serializable
     data class SurveyIncluded(
-        val text: String
-    )
+        val id: String,
+        val text: String,
+        @SerialName("display_type") val displayType: String,
+        @SerialName("display_order") val displayOrder: Int,
+        val answers: List<SurveyAnswer>
+    ) {
+        fun toSurveyDetail(): SurveyDetail.SurveyIncluded = SurveyDetail.SurveyIncluded(
+            id,
+            text,
+            displayType,
+            displayOrder,
+            answers.map { it.toSurveyDetail() }
+        )
+    }
+
+    @Serializable
+    data class SurveyAnswer(
+        val id: String,
+        val text: String,
+        @SerialName("display_order") val displayOrder: Int,
+        @SerialName("input_mask_placeholder") val inputMaskPlaceholder: String
+    ) {
+        fun toSurveyDetail(): SurveyDetail.SurveyAnswer = SurveyDetail.SurveyAnswer(
+            id,
+            text,
+            displayOrder,
+            inputMaskPlaceholder
+        )
+    }
 
     fun toSurveyDetail(): SurveyDetail = SurveyDetail(
         title,
         description,
         isActive,
         coverImageUrl,
-        questions.map { SurveyDetail.SurveyIncluded(it.text) }
+        questions.map { it.toSurveyDetail() }
     )
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/extensions/Start.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/extensions/Start.kt
@@ -4,6 +4,7 @@ import co.nimblehq.blisskmmic.di.koin.initKoin
 import co.nimblehq.blisskmmic.presentation.modules.login.LoginViewModel
 import co.nimblehq.blisskmmic.presentation.modules.resetpassword.ResetPasswordViewModel
 import co.nimblehq.blisskmmic.presentation.modules.splash.SplashViewModel
+import co.nimblehq.blisskmmic.presentation.modules.surveydetail.SurveyDetailViewModel
 import co.nimblehq.blisskmmic.presentation.modules.surveyselection.SurveySelectionViewModel
 import org.koin.core.Koin
 import org.koin.core.KoinApplication
@@ -17,4 +18,6 @@ val Koin.resetPasswordViewModel: ResetPasswordViewModel
 val Koin.splashViewModel: SplashViewModel
     get() = get()
 val Koin.surveySelectionViewModel: SurveySelectionViewModel
+    get() = get()
+val Koin.surveyDetailViewModel: SurveyDetailViewModel
     get() = get()

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/UseCaseModule.kt
@@ -12,4 +12,5 @@ val useCaseModule = module {
     single<GetProfileUseCase> { GetProfileUseCaseImpl(get()) }
     single<GetAppVersionUseCase> { GetAppVersionUseCaseImpl(get()) }
     single<LogOutUseCase> { LogOutUseCaseImpl(get()) }
+    single<GetSurveyDetailUseCase> { GetSurveyDetailUseCaseImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/di/koin/modules/ViewModelModule.kt
@@ -3,6 +3,7 @@ package co.nimblehq.blisskmmic.di.koin.modules
 import co.nimblehq.blisskmmic.presentation.modules.login.LoginViewModel
 import co.nimblehq.blisskmmic.presentation.modules.resetpassword.ResetPasswordViewModel
 import co.nimblehq.blisskmmic.presentation.modules.splash.SplashViewModel
+import co.nimblehq.blisskmmic.presentation.modules.surveydetail.SurveyDetailViewModel
 import co.nimblehq.blisskmmic.presentation.modules.surveyselection.SurveySelectionViewModel
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
@@ -13,4 +14,5 @@ val viewModelModule = module {
     factoryOf(::ResetPasswordViewModel)
     factoryOf(::SplashViewModel)
     factoryOf(::SurveySelectionViewModel)
+    factory { SurveyDetailViewModel(get()) }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/model/SurveyDetail.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/model/SurveyDetail.kt
@@ -1,7 +1,5 @@
 package co.nimblehq.blisskmmic.domain.model
 
-import kotlinx.serialization.SerialName
-
 data class SurveyDetail(
     val title: String,
     val description: String,

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/model/SurveyDetail.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/model/SurveyDetail.kt
@@ -1,5 +1,7 @@
 package co.nimblehq.blisskmmic.domain.model
 
+import kotlinx.serialization.SerialName
+
 data class SurveyDetail(
     val title: String,
     val description: String,
@@ -8,6 +10,17 @@ data class SurveyDetail(
     val questions: List<SurveyIncluded>
 ) {
     data class SurveyIncluded(
-        val text: String
+        val id: String,
+        val text: String,
+        val displayType: String,
+        val displayOrder: Int,
+        val answers: List<SurveyAnswer>
+    )
+
+    data class SurveyAnswer(
+        val id: String,
+        val text: String,
+        val displayOrder: Int,
+        val inputMaskPlaceholder: String
     )
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/model/SurveyDetail.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/model/SurveyDetail.kt
@@ -19,8 +19,8 @@ data class SurveyDetail(
 
     data class SurveyAnswer(
         val id: String,
-        val text: String,
+        val text: String?,
         val displayOrder: Int,
-        val inputMaskPlaceholder: String
+        val inputMaskPlaceholder: String?
     )
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/usecase/GetSurveyDetailUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/domain/usecase/GetSurveyDetailUseCase.kt
@@ -1,0 +1,19 @@
+package co.nimblehq.blisskmmic.domain.usecase
+
+import co.nimblehq.blisskmmic.domain.model.SurveyDetail
+import co.nimblehq.blisskmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+
+interface GetSurveyDetailUseCase {
+
+    operator fun invoke(id: String): Flow<SurveyDetail>
+}
+
+class GetSurveyDetailUseCaseImpl(
+    private val repository: SurveyRepository
+) : GetSurveyDetailUseCase {
+
+    override operator fun invoke(id: String): Flow<SurveyDetail> {
+        return repository.getSurveyDetail(id)
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
@@ -9,63 +9,66 @@ data class SurveyDetailUiModel (
     val coverImageUrl: String,
     val questions: List<SurveyIncluded>
 ) {
+
     data class SurveyIncluded(
         val id: String,
         val text: String,
-        val displayType: String,
+        val displayType: DisplayType,
         val displayOrder: Int,
         val answers: List<SurveyAnswer>
-    ) {
-
-        constructor(survey: SurveyDetail.SurveyIncluded):
-            this(
-                survey.id,
-                survey.text,
-                survey.displayType,
-                survey.displayOrder,
-                survey.answers.map { SurveyAnswer(it) }
-            )
-    }
+    )
 
     data class SurveyAnswer(
         val id: String,
         val text: String?,
         val displayOrder: Int,
         val inputMaskPlaceholder: String?
-    ) {
+    )
 
-        constructor(answer: SurveyDetail.SurveyAnswer):
-            this(
-                answer.id,
-                answer.text,
-                answer.displayOrder,
-                answer.inputMaskPlaceholder
-            )
-    }
+    enum class DisplayType {
+        DEFAULT,
+        INTRO,
+        STAR,
+        SMILEY,
+        HEART,
+        NPS,
+        TEXTAREA,
+        TEXTFIELD,
+        OUTRO,
+        CHOICE;
 
-    companion object {
-
-        const val Default = "default"
-        const val Intro = "intro"
-        const val Star = "star"
-        const val Smiley = "smiley"
-        const val Heart = "heart"
-        const val NPS = "nps"
-        const val TextArea = "textarea"
-        const val TextField = "textfield"
-        const val Outro = "outro"
-        const val Choice = "choice"
+        companion object {
+            fun from(type: String?): DisplayType =
+                values().find { it.name == type } ?: DEFAULT
+        }
     }
 
     val largeImageUrl
         get() = coverImageUrl.plus("l")
-
-    constructor(detail: SurveyDetail):
-        this(
-            detail.title,
-            detail.description,
-            detail.isActive,
-            detail.coverImageUrl,
-            detail.questions.map { SurveyIncluded(it) }
-        )
 }
+
+fun SurveyDetail.toSurveyDetailUiModel() =
+    SurveyDetailUiModel(
+        title,
+        description,
+        isActive,
+        coverImageUrl,
+        questions.map { it.toSurveyDetailUiModel() }
+    )
+
+private fun SurveyDetail.SurveyIncluded.toSurveyDetailUiModel() =
+    SurveyDetailUiModel.SurveyIncluded(
+        id,
+        text,
+        SurveyDetailUiModel.DisplayType.from(displayType.uppercase()),
+        displayOrder,
+        answers.map { it.toSurveyDetailUiModel() }
+    )
+
+private fun SurveyDetail.SurveyAnswer.toSurveyDetailUiModel() =
+    SurveyDetailUiModel.SurveyAnswer(
+        id,
+        text,
+        displayOrder,
+        inputMaskPlaceholder
+    )

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
@@ -1,0 +1,23 @@
+package co.nimblehq.blisskmmic.presentation.model
+
+import co.nimblehq.blisskmmic.domain.model.SurveyDetail
+
+data class SurveyDetailUiModel (
+    val title: String,
+    val description: String,
+    val isActive: Boolean,
+    val coverImageUrl: String,
+    val questions: List<String>
+) {
+    val largeImageUrl
+        get() = coverImageUrl.plus("l")
+
+    constructor(detail: SurveyDetail):
+        this(
+            detail.title,
+            detail.description,
+            detail.isActive,
+            detail.coverImageUrl,
+            detail.questions.map { it.text }
+        )
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
@@ -29,9 +29,9 @@ data class SurveyDetailUiModel (
 
     data class SurveyAnswer(
         val id: String,
-        val text: String,
+        val text: String?,
         val displayOrder: Int,
-        val inputMaskPlaceholder: String
+        val inputMaskPlaceholder: String?
     ) {
 
         constructor(answer: SurveyDetail.SurveyAnswer):

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/model/SurveyDetailUiModel.kt
@@ -7,8 +7,56 @@ data class SurveyDetailUiModel (
     val description: String,
     val isActive: Boolean,
     val coverImageUrl: String,
-    val questions: List<String>
+    val questions: List<SurveyIncluded>
 ) {
+    data class SurveyIncluded(
+        val id: String,
+        val text: String,
+        val displayType: String,
+        val displayOrder: Int,
+        val answers: List<SurveyAnswer>
+    ) {
+
+        constructor(survey: SurveyDetail.SurveyIncluded):
+            this(
+                survey.id,
+                survey.text,
+                survey.displayType,
+                survey.displayOrder,
+                survey.answers.map { SurveyAnswer(it) }
+            )
+    }
+
+    data class SurveyAnswer(
+        val id: String,
+        val text: String,
+        val displayOrder: Int,
+        val inputMaskPlaceholder: String
+    ) {
+
+        constructor(answer: SurveyDetail.SurveyAnswer):
+            this(
+                answer.id,
+                answer.text,
+                answer.displayOrder,
+                answer.inputMaskPlaceholder
+            )
+    }
+
+    companion object {
+
+        const val Default = "default"
+        const val Intro = "intro"
+        const val Star = "star"
+        const val Smiley = "smiley"
+        const val Heart = "heart"
+        const val NPS = "nps"
+        const val TextArea = "textarea"
+        const val TextField = "textfield"
+        const val Outro = "outro"
+        const val Choice = "choice"
+    }
+
     val largeImageUrl
         get() = coverImageUrl.plus("l")
 
@@ -18,6 +66,6 @@ data class SurveyDetailUiModel (
             detail.description,
             detail.isActive,
             detail.coverImageUrl,
-            detail.questions.map { it.text }
+            detail.questions.map { SurveyIncluded(it) }
         )
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModel.kt
@@ -1,0 +1,57 @@
+package co.nimblehq.blisskmmic.presentation.modules.surveydetail
+
+import co.nimblehq.blisskmmic.data.network.helpers.toErrorMessage
+import co.nimblehq.blisskmmic.domain.model.SurveyDetail
+import co.nimblehq.blisskmmic.domain.usecase.GetSurveyDetailUseCase
+import co.nimblehq.blisskmmic.presentation.model.SurveyDetailUiModel
+import co.nimblehq.blisskmmic.presentation.modules.BaseViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class SurveyDetailViewState(
+    val surveyDetail: SurveyDetailUiModel? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+) {
+    constructor() : this(isLoading = false)
+    constructor(error: String?) : this(null, false, error)
+}
+
+class SurveyDetailViewModel(
+    private val getSurveyDetailUseCase: GetSurveyDetailUseCase,
+    private val surveyId: String
+): BaseViewModel() {
+
+    private val mutableViewState: MutableStateFlow<SurveyDetailViewState> =
+        MutableStateFlow(SurveyDetailViewState())
+
+    val viewState: StateFlow<SurveyDetailViewState> = mutableViewState
+
+    fun getDetail() {
+        setStateLoading()
+        viewModelScope.launch {
+            getSurveyDetailUseCase(surveyId)
+                .catch { error -> handleLoginError(error) }
+                .collect { handleSurveyDetail(it) }
+        }
+    }
+
+    private fun setStateLoading() {
+        mutableViewState.update {
+            SurveyDetailViewState(isLoading = true)
+        }
+    }
+
+    private fun handleLoginError(error: Throwable) {
+        mutableViewState.update { SurveyDetailViewState(isLoading = false, error = error.toErrorMessage()) }
+    }
+
+    private fun handleSurveyDetail(detail: SurveyDetail) {
+        mutableViewState.update {
+            SurveyDetailViewState(surveyDetail = SurveyDetailUiModel(detail), isLoading = false)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModel.kt
@@ -16,7 +16,7 @@ data class SurveyDetailViewState(
     val surveyDetail: SurveyDetailUiModel? = null,
     val isLoading: Boolean = false,
     val isShowingQuestion: Boolean = false,
-    val error: String? = null,
+    val error: String? = null
 ) {
     constructor() : this(isLoading = false)
     constructor(error: String?) : this(null, false, false, error)

--- a/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModel.kt
@@ -4,6 +4,7 @@ import co.nimblehq.blisskmmic.data.network.helpers.toErrorMessage
 import co.nimblehq.blisskmmic.domain.model.SurveyDetail
 import co.nimblehq.blisskmmic.domain.usecase.GetSurveyDetailUseCase
 import co.nimblehq.blisskmmic.presentation.model.SurveyDetailUiModel
+import co.nimblehq.blisskmmic.presentation.model.toSurveyDetailUiModel
 import co.nimblehq.blisskmmic.presentation.modules.BaseViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,13 +37,13 @@ class SurveyDetailViewModel(
     }
 
     fun getDetail() {
-        surveyId ?: return
-        val id = surveyId ?: ""
-        setStateLoading()
-        viewModelScope.launch {
-            getSurveyDetailUseCase(id)
-                .catch { error -> handleError(error) }
-                .collect { handleSurveyDetail(it) }
+        surveyId?.let {
+            setStateLoading()
+            viewModelScope.launch {
+                getSurveyDetailUseCase(it)
+                    .catch { error -> handleError(error) }
+                    .collect { handleSurveyDetail(it) }
+            }
         }
     }
 
@@ -79,7 +80,7 @@ class SurveyDetailViewModel(
         val currentState = viewState.value
         mutableViewState.update {
             SurveyDetailViewState(
-                surveyDetail = SurveyDetailUiModel(detail),
+                surveyDetail = detail.toSurveyDetailUiModel(),
                 isLoading = false,
                 isShowingQuestion = currentState.isShowingQuestion
             )

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/domain/usecase/GetSurveyDetailUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/domain/usecase/GetSurveyDetailUseCaseTest.kt
@@ -1,0 +1,58 @@
+package co.nimblehq.blisskmmic.domain.usecase
+
+import app.cash.turbine.test
+import co.nimblehq.blisskmmic.domain.model.*
+import co.nimblehq.blisskmmic.domain.model.fakeSurveyDetail
+import co.nimblehq.blisskmmic.domain.repository.MockSurveyRepository
+import co.nimblehq.blisskmmic.domain.repository.SurveyRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mocker
+import org.kodein.mock.UsesFakes
+import org.kodein.mock.UsesMocks
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@UsesMocks(SurveyRepository::class)
+@UsesFakes(SurveyDetail::class)
+class GetSurveyDetailUseCaseTest {
+
+    private val mocker = Mocker()
+    private val surveyRepository = MockSurveyRepository(mocker)
+    private val survey = fakeSurveyDetail()
+    private val getSurveyDetailUseCase = GetSurveyDetailUseCaseImpl(surveyRepository)
+
+    @BeforeTest
+    fun setUp() {
+        mocker.reset()
+    }
+
+    @Test
+    fun `When calling getSurveyDetail with a success response - it returns correct object`() = runTest {
+        mocker.every {
+            getSurveyDetailUseCase(isAny())
+        } returns flowOf(survey)
+
+        getSurveyDetailUseCase("")
+            .test {
+                awaitItem().title shouldBe survey.title
+                awaitComplete()
+            }
+    }
+
+    @Test
+    fun `When calling getSurveyDetail with a failure response - it returns correct error`() = runTest {
+        mocker.every {
+            getSurveyDetailUseCase(isAny())
+        } returns flow { error("Fail") }
+
+        getSurveyDetailUseCase("")
+            .test {
+                awaitError().message shouldBe "Fail"
+            }
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/blisskmmic/presentation/modules/surveydetail/SurveyDetailViewModelTest.kt
@@ -1,0 +1,146 @@
+package co.nimblehq.blisskmmic.presentation.modules.surveydetail
+
+import app.cash.turbine.test
+import co.nimblehq.blisskmmic.domain.model.SurveyDetail
+import co.nimblehq.blisskmmic.domain.usecase.GetSurveyDetailUseCase
+import co.nimblehq.blisskmmic.helpers.flow.delayFlowOf
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Fake
+import org.kodein.mock.Mock
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class SurveyDetailViewModelTest: TestsWithMocks() {
+
+    @Mock
+    lateinit var getSurveyDetailUseCase: GetSurveyDetailUseCase
+    @Fake
+    lateinit var survey: SurveyDetail
+
+    private val mainThreadSurrogate = newSingleThreadContext("UI thread")
+
+    private val surveyDetailViewModel by withMocks { SurveyDetailViewModel(getSurveyDetailUseCase) }
+
+    override fun setUpMocks() = injectMocks(mocker)
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(mainThreadSurrogate)
+        mocker.reset()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        mainThreadSurrogate.close()
+    }
+
+    @Test
+    fun `When calling getDetail before setId - it does not trigger getSurveyDetailUseCase`() = runTest {
+        mocker.every {
+            getSurveyDetailUseCase(isAny())
+        } returns flowOf(survey)
+
+        surveyDetailViewModel.getDetail()
+
+        verify {}
+    }
+
+    @Test
+    fun `When calling getDetail with success response - it changes viewState to success with correct item`() = runTest {
+        surveyDetailViewModel.setSurveyId("")
+
+        mocker.every {
+            getSurveyDetailUseCase(isAny())
+        } returns delayFlowOf(survey)
+
+        surveyDetailViewModel.getDetail()
+
+        surveyDetailViewModel
+            .viewState
+            .test {
+                awaitItem().isLoading shouldBe true
+                val result = awaitItem()
+                result.isLoading shouldBe false
+                result.surveyDetail?.title shouldBe survey.title
+                cancel()
+            }
+    }
+
+    @Test
+    fun `When calling showQuestion with existing detail - it changes viewState with correct item`() = runTest {
+        surveyDetailViewModel.setSurveyId("")
+
+        mocker.every {
+            getSurveyDetailUseCase(isAny())
+        } returns delayFlowOf(survey)
+
+        surveyDetailViewModel.getDetail()
+
+        surveyDetailViewModel
+            .viewState
+            .test {
+                awaitItem().isLoading shouldBe true
+                val result = awaitItem()
+                result.isLoading shouldBe false
+                result.surveyDetail?.title shouldBe survey.title
+                surveyDetailViewModel.showQuestion()
+                awaitItem().isShowingQuestion shouldBe true
+                cancel()
+            }
+    }
+
+    @Test
+    fun `When calling showQuestion with no detail - it should call getDetail`() = runTest {
+        surveyDetailViewModel.setSurveyId("")
+
+        mocker.every {
+            getSurveyDetailUseCase(isAny())
+        } returns delayFlowOf(survey)
+
+        surveyDetailViewModel.showQuestion()
+
+        surveyDetailViewModel
+            .viewState
+            .test {
+                awaitItem().isShowingQuestion shouldBe true
+                val result = awaitItem()
+                result.isLoading shouldBe false
+                result.surveyDetail?.title shouldBe survey.title
+                result.isShowingQuestion shouldBe true
+                cancel()
+            }
+    }
+
+    @Test
+    fun `When calling getDetail with faliure response - it changes viewState to error`() = runTest {
+        surveyDetailViewModel.setSurveyId("")
+
+        val errorMessage = "Test Error"
+        mocker.every {
+            getSurveyDetailUseCase(isAny())
+        } returns delayFlowOf(errorMessage)
+
+        surveyDetailViewModel.getDetail()
+
+        surveyDetailViewModel
+            .viewState
+            .test {
+                awaitItem().isLoading shouldBe true
+                val result = awaitItem()
+                result.isLoading shouldBe false
+                result.error shouldBe errorMessage
+                cancel()
+            }
+    }
+}


### PR DESCRIPTION
- close #28

## What happened

Integrate Survey Detail.
Call APIs when showing Survey Detail.
Navigate survey detail shows real questions title.
 
## Insight

- Add supporting models for `SurveyDetail`.
- Use enum for mapping `display_type`.
- Add enum helper for mapping string with default value.
- Add `SurveyDetailViewModel`.
- SurveyDetail API is call as soon as the SurveyDetail page appears to smooth the loading process.
  - User can tap `Start` and wait for the API to finish calling.
 
## Proof Of Work




https://user-images.githubusercontent.com/6356137/216917915-3de2540e-6c39-452b-a3cf-2fef37a08029.mp4




